### PR TITLE
Compiler: Add `CrateIdentifierPreparer` for properly quoting reserved words

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 - Added/reactivated documentation as `sqlalchemy-cratedb`
+- Added `CrateIdentifierPreparer`, in order to quote reserved words
+  like `object` properly, for example when used as column names.
 
 ## 2024/06/13 0.37.0
 - Added support for CrateDB's [FLOAT_VECTOR] data type and its accompanying

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -29,7 +29,8 @@ from sqlalchemy.util import asbool, to_list
 
 from .compiler import (
     CrateTypeCompiler,
-    CrateDDLCompiler
+    CrateDDLCompiler,
+    CrateIdentifierPreparer,
 )
 from crate.client.exceptions import TimezoneUnawareException
 from .sa_version import SA_VERSION, SA_1_4, SA_2_0
@@ -174,6 +175,7 @@ class CrateDialect(default.DefaultDialect):
     statement_compiler = statement_compiler
     ddl_compiler = CrateDDLCompiler
     type_compiler = CrateTypeCompiler
+    preparer = CrateIdentifierPreparer
     use_insertmanyvalues = True
     use_insertmanyvalues_wo_returning = True
     supports_multivalues_insert = True


### PR DESCRIPTION
## About
By using this component of the SQLAlchemy dialect compiler, it can define CrateDB's reserved words to be quoted properly when building SQL statements.

## References
In this case, `OBJECT` needs to be quoted when used as column name.
- https://github.com/RDFLib/rdflib-sqlalchemy/pull/106

## Backlog
- [x] Changelog item
- [x] Software tests
