### PR TITLE
Types: Unlock supporting timezone-aware `DateTime` fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
   CrateDB dialect table options.
 - Fixed SQL rendering of special DDL table options in `CrateDDLCompiler`.
   Before, configuring `crate_"translog.durability"` was not possible.
+- Unlocked supporting timezone-aware `DateTime` fields
 
 ## 2024/06/13 0.37.0
 - Added support for CrateDB's [FLOAT_VECTOR] data type and its accompanying

--- a/src/sqlalchemy_cratedb/compiler.py
+++ b/src/sqlalchemy_cratedb/compiler.py
@@ -225,7 +225,7 @@ class CrateTypeCompiler(compiler.GenericTypeCompiler):
         return 'SHORT'
 
     def visit_datetime(self, type_, **kw):
-        return 'TIMESTAMP'
+        return self.visit_TIMESTAMP(type_, **kw)
 
     def visit_date(self, type_, **kw):
         return 'TIMESTAMP'
@@ -244,6 +244,16 @@ class CrateTypeCompiler(compiler.GenericTypeCompiler):
         if dimensions is None:
             raise ValueError("FloatVector must be initialized with dimension size")
         return f"FLOAT_VECTOR({dimensions})"
+
+    def visit_TIMESTAMP(self, type_, **kw):
+        """
+        Support for `TIMESTAMP WITH|WITHOUT TIME ZONE`.
+
+        From `sqlalchemy.dialects.postgresql.base.PGTypeCompiler`.
+        """
+        return "TIMESTAMP %s" % (
+            (type_.timezone and "WITH" or "WITHOUT") + " TIME ZONE",
+        )
 
 
 class CrateCompiler(compiler.SQLCompiler):

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -39,8 +39,8 @@ TYPES_MAP = {
     "boolean": sqltypes.Boolean,
     "short": sqltypes.SmallInteger,
     "smallint": sqltypes.SmallInteger,
-    "timestamp": sqltypes.TIMESTAMP,
-    "timestamp with time zone": sqltypes.TIMESTAMP,
+    "timestamp": sqltypes.TIMESTAMP(timezone=False),
+    "timestamp with time zone": sqltypes.TIMESTAMP(timezone=True),
     "object": ObjectType,
     "integer": sqltypes.Integer,
     "long": sqltypes.NUMERIC,
@@ -61,8 +61,8 @@ try:
     TYPES_MAP["boolean_array"] = ARRAY(sqltypes.Boolean)
     TYPES_MAP["short_array"] = ARRAY(sqltypes.SmallInteger)
     TYPES_MAP["smallint_array"] = ARRAY(sqltypes.SmallInteger)
-    TYPES_MAP["timestamp_array"] = ARRAY(sqltypes.TIMESTAMP)
-    TYPES_MAP["timestamp with time zone_array"] = ARRAY(sqltypes.TIMESTAMP)
+    TYPES_MAP["timestamp_array"] = ARRAY(sqltypes.TIMESTAMP(timezone=False))
+    TYPES_MAP["timestamp with time zone_array"] = ARRAY(sqltypes.TIMESTAMP(timezone=True))
     TYPES_MAP["long_array"] = ARRAY(sqltypes.NUMERIC)
     TYPES_MAP["bigint_array"] = ARRAY(sqltypes.NUMERIC)
     TYPES_MAP["double_array"] = ARRAY(sqltypes.DECIMAL)
@@ -147,8 +147,9 @@ class DateTime(sqltypes.DateTime):
 
 
 colspecs = {
+    sqltypes.Date: Date,
     sqltypes.DateTime: DateTime,
-    sqltypes.Date: Date
+    sqltypes.TIMESTAMP: DateTime,
 }
 
 

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -117,7 +117,7 @@ class DateTime(sqltypes.DateTime):
         def process(value):
             if value is not None:
                 assert isinstance(value, datetime)
-                return value.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                return value.strftime('%Y-%m-%dT%H:%M:%S.%f%z')
             return value
         return process
 

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -32,7 +32,6 @@ from .compiler import (
     CrateDDLCompiler,
     CrateIdentifierPreparer,
 )
-from crate.client.exceptions import TimezoneUnawareException
 from .sa_version import SA_VERSION, SA_1_4, SA_2_0
 from .type import FloatVector, ObjectArray, ObjectType
 
@@ -114,14 +113,10 @@ class Date(sqltypes.Date):
 
 class DateTime(sqltypes.DateTime):
 
-    TZ_ERROR_MSG = "Timezone aware datetime objects are not supported"
-
     def bind_processor(self, dialect):
         def process(value):
             if value is not None:
                 assert isinstance(value, datetime)
-                if value.tzinfo is not None:
-                    raise TimezoneUnawareException(DateTime.TZ_ERROR_MSG)
                 return value.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
             return value
         return process

--- a/tests/create_table_test.py
+++ b/tests/create_table_test.py
@@ -67,8 +67,10 @@ class SqlAlchemyCreateTableTest(TestCase):
              '\n\tlong_col1 LONG, \n\tlong_col2 LONG, '
              '\n\tbool_col BOOLEAN, '
              '\n\tshort_col SHORT, '
-             '\n\tdatetime_col TIMESTAMP, \n\tdate_col TIMESTAMP, '
-             '\n\tfloat_col FLOAT, \n\tdouble_col DOUBLE, '
+             '\n\tdatetime_col TIMESTAMP WITHOUT TIME ZONE, '
+             '\n\tdate_col TIMESTAMP, '
+             '\n\tfloat_col FLOAT, '
+             '\n\tdouble_col DOUBLE, '
              '\n\tPRIMARY KEY (string_col)\n)\n\n'),
             ())
 
@@ -286,7 +288,7 @@ class SqlAlchemyCreateTableTest(TestCase):
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE t (\n\t'
              'pk STRING NOT NULL, \n\t'
-             'a TIMESTAMP DEFAULT now(), \n\t'
+             'a TIMESTAMP WITHOUT TIME ZONE DEFAULT now(), \n\t'
              'PRIMARY KEY (pk)\n)\n\n'), ())
 
     def test_column_server_default_string(self):
@@ -312,7 +314,7 @@ class SqlAlchemyCreateTableTest(TestCase):
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE t (\n\t'
              'pk STRING NOT NULL, \n\t'
-             'a TIMESTAMP DEFAULT now(), \n\t'
+             'a TIMESTAMP WITHOUT TIME ZONE DEFAULT now(), \n\t'
              'PRIMARY KEY (pk)\n)\n\n'), ())
 
     def test_column_server_default_text_constant(self):

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -22,12 +22,13 @@
 from __future__ import absolute_import
 
 from datetime import datetime, tzinfo, timedelta
+import datetime as dt
 from unittest import TestCase, skipIf
 from unittest.mock import patch, MagicMock
 
+import pytest
 import sqlalchemy as sa
-from sqlalchemy.exc import DBAPIError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from sqlalchemy_cratedb import SA_VERSION, SA_1_4
 
@@ -87,9 +88,82 @@ class SqlAlchemyDateAndDateTimeTest(TestCase):
         ]
         self.session.query(self.Character).first()
 
-    def test_date_cannot_handle_tz_aware_datetime(self):
+    def test_date_can_handle_tz_aware_datetime(self):
         character = self.Character()
         character.name = "Athur"
         character.timestamp = datetime(2009, 5, 13, 19, 19, 30, tzinfo=CST())
         self.session.add(character)
-        self.assertRaises(DBAPIError, self.session.commit)
+
+
+Base = declarative_base()
+
+
+class FooBar(Base):
+    __tablename__ = "foobar"
+    name = sa.Column(sa.String, primary_key=True)
+    date = sa.Column(sa.Date)
+    datetime = sa.Column(sa.DateTime)
+
+
+@pytest.fixture
+def session(cratedb_service):
+    engine = cratedb_service.database.engine
+    session = sessionmaker(bind=engine)()
+
+    Base.metadata.drop_all(engine, checkfirst=True)
+    Base.metadata.create_all(engine, checkfirst=True)
+    return session
+
+
+@pytest.mark.skipif(SA_VERSION < SA_1_4, reason="Test case not supported on SQLAlchemy 1.3")
+def test_datetime_notz(session):
+    """
+    An integration test for `sa.Date` and `sa.DateTime`, not using timezones.
+    """
+
+    # Insert record.
+    foo_item = FooBar(
+        name="foo",
+        date=dt.date(2009, 5, 13),
+        datetime=dt.datetime(2009, 5, 13, 19, 19, 30, 123456),
+    )
+    session.add(foo_item)
+    session.commit()
+    session.execute(sa.text("REFRESH TABLE foobar"))
+
+    # Query record.
+    result = session.execute(sa.select(FooBar.name, FooBar.date, FooBar.datetime)).mappings().first()
+
+    # Compare outcome.
+    assert result["date"].year == 2009
+    assert result["datetime"].year == 2009
+    assert result["datetime"].tzname() is None
+    assert result["datetime"].timetz() == dt.time(19, 19, 30, 123000)
+    assert result["datetime"].tzinfo is None
+
+
+@pytest.mark.skipif(SA_VERSION < SA_1_4, reason="Test case not supported on SQLAlchemy 1.3")
+def test_datetime_tz(session):
+    """
+    An integration test for `sa.Date` and `sa.DateTime`, now using timezones.
+    """
+
+    # Insert record.
+    foo_item = FooBar(
+        name="foo",
+        date=dt.date(2009, 5, 13),
+        datetime=dt.datetime(2009, 5, 13, 19, 19, 30, 123456, tzinfo=CST()),
+    )
+    session.add(foo_item)
+    session.commit()
+    session.execute(sa.text("REFRESH TABLE foobar"))
+
+    # Query record.
+    result = session.execute(sa.select(FooBar.name, FooBar.date, FooBar.datetime)).mappings().first()
+
+    # Compare outcome.
+    assert result["date"].year == 2009
+    assert result["datetime"].year == 2009
+    assert result["datetime"].tzname() is None
+    assert result["datetime"].timetz() == dt.time(19, 19, 30, 123000)
+    assert result["datetime"].tzinfo is None

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -21,7 +21,6 @@
 
 from __future__ import absolute_import
 
-from datetime import tzinfo, timedelta
 import datetime as dt
 from unittest import TestCase, skipIf
 from unittest.mock import patch, MagicMock
@@ -38,6 +37,11 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
+
 from crate.client.cursor import Cursor
 
 
@@ -46,21 +50,9 @@ FakeCursor = MagicMock(name='FakeCursor', spec=Cursor)
 FakeCursor.return_value = fake_cursor
 
 
-class CST(tzinfo):
-    """
-    Timezone object for CST
-    """
-
-    def utcoffset(self, date_time):
-        return timedelta(seconds=-3600)
-
-    def dst(self, date_time):
-        return timedelta(seconds=-7200)
-
-
 INPUT_DATE = dt.date(2009, 5, 13)
 INPUT_DATETIME_NOTZ = dt.datetime(2009, 5, 13, 19, 19, 30, 123456)
-INPUT_DATETIME_TZ = dt.datetime(2009, 5, 13, 19, 19, 30, 123456, tzinfo=CST())
+INPUT_DATETIME_TZ = dt.datetime(2009, 5, 13, 19, 19, 30, 123456, tzinfo=zoneinfo.ZoneInfo("Europe/Kyiv"))
 OUTPUT_DATE = INPUT_DATE
 OUTPUT_TIME = dt.time(19, 19, 30, 123000)
 OUTPUT_DATETIME_NOTZ = dt.datetime(2009, 5, 13, 19, 19, 30, 123000)

--- a/tests/datetime_test.py
+++ b/tests/datetime_test.py
@@ -51,12 +51,13 @@ FakeCursor.return_value = fake_cursor
 
 
 INPUT_DATE = dt.date(2009, 5, 13)
-INPUT_DATETIME_NOTZ = dt.datetime(2009, 5, 13, 19, 19, 30, 123456)
-INPUT_DATETIME_TZ = dt.datetime(2009, 5, 13, 19, 19, 30, 123456, tzinfo=zoneinfo.ZoneInfo("Europe/Kyiv"))
+INPUT_DATETIME_NOTZ = dt.datetime(2009, 5, 13, 19, 00, 30, 123456)
+INPUT_DATETIME_TZ = dt.datetime(2009, 5, 13, 19, 00, 30, 123456, tzinfo=zoneinfo.ZoneInfo("Europe/Kyiv"))
 OUTPUT_DATE = INPUT_DATE
-OUTPUT_TIME = dt.time(19, 19, 30, 123000)
-OUTPUT_DATETIME_NOTZ = dt.datetime(2009, 5, 13, 19, 19, 30, 123000)
-OUTPUT_DATETIME_TZ = dt.datetime(2009, 5, 13, 19, 19, 30, 123000)
+OUTPUT_TIMETZ_NOTZ = dt.time(19, 00, 30, 123000)
+OUTPUT_TIMETZ_TZ = dt.time(16, 00, 30, 123000)
+OUTPUT_DATETIME_NOTZ = dt.datetime(2009, 5, 13, 19, 00, 30, 123000)
+OUTPUT_DATETIME_TZ = dt.datetime(2009, 5, 13, 16, 00, 30, 123000)
 
 
 @skipIf(SA_VERSION < SA_1_4, "SQLAlchemy 1.3 suddenly has problems with these test cases")
@@ -143,11 +144,11 @@ def test_datetime_notz(session):
     assert result["date"] == OUTPUT_DATE
     assert result["datetime_notz"] == OUTPUT_DATETIME_NOTZ
     assert result["datetime_notz"].tzname() is None
-    assert result["datetime_notz"].timetz() == OUTPUT_TIME
+    assert result["datetime_notz"].timetz() == OUTPUT_TIMETZ_NOTZ
     assert result["datetime_notz"].tzinfo is None
     assert result["datetime_tz"] == OUTPUT_DATETIME_NOTZ
     assert result["datetime_tz"].tzname() is None
-    assert result["datetime_tz"].timetz() == OUTPUT_TIME
+    assert result["datetime_tz"].timetz() == OUTPUT_TIMETZ_NOTZ
     assert result["datetime_tz"].tzinfo is None
 
 
@@ -169,16 +170,17 @@ def test_datetime_tz(session):
     session.execute(sa.text("REFRESH TABLE foobar"))
 
     # Query record.
+    session.expunge(foo_item)
     result = session.execute(sa.select(
         FooBar.name, FooBar.date, FooBar.datetime_notz, FooBar.datetime_tz)).mappings().first()
 
     # Compare outcome.
     assert result["date"] == OUTPUT_DATE
-    assert result["datetime_notz"] == OUTPUT_DATETIME_TZ
+    assert result["datetime_notz"] == OUTPUT_DATETIME_NOTZ
     assert result["datetime_notz"].tzname() is None
-    assert result["datetime_notz"].timetz() == OUTPUT_TIME
+    assert result["datetime_notz"].timetz() == OUTPUT_TIMETZ_NOTZ
     assert result["datetime_notz"].tzinfo is None
     assert result["datetime_tz"] == OUTPUT_DATETIME_TZ
     assert result["datetime_tz"].tzname() is None
-    assert result["datetime_tz"].timetz() == OUTPUT_TIME
+    assert result["datetime_tz"].timetz() == OUTPUT_TIMETZ_TZ
     assert result["datetime_tz"].tzinfo is None

--- a/tests/update_test.py
+++ b/tests/update_test.py
@@ -81,7 +81,7 @@ class SqlAlchemyUpdateTest(TestCase):
         args = args[1]
         self.assertEqual(expected_stmt, stmt)
         self.assertEqual(40, args[0])
-        dt = datetime.strptime(args[1], '%Y-%m-%dT%H:%M:%S.%fZ')
+        dt = datetime.strptime(args[1], '%Y-%m-%dT%H:%M:%S.%f')
         self.assertIsInstance(dt, datetime)
         self.assertGreater(dt, now)
         self.assertEqual('Arthur', args[2])
@@ -110,6 +110,6 @@ class SqlAlchemyUpdateTest(TestCase):
         self.assertEqual(expected_stmt, stmt)
         self.assertEqual('Julia', args[0])
         self.assertEqual({'favorite_book': 'Romeo & Juliet'}, args[1])
-        dt = datetime.strptime(args[2], '%Y-%m-%dT%H:%M:%S.%fZ')
+        dt = datetime.strptime(args[2], '%Y-%m-%dT%H:%M:%S.%f')
         self.assertIsInstance(dt, datetime)
         self.assertGreater(dt, before_update_time)


### PR DESCRIPTION
## About
Timezone-aware SQLAlchemy `DateTime` fields apparently are supported already. This patch just removes a corresponding assertion which prevented them from actually being used.

## References
Originally, this is coming from a [monkeypatch to meltano-target-cratedb](https://github.com/crate-workbench/meltano-target-cratedb/blob/2b20640/target_cratedb/sqlalchemy/patch.py#L39-L51). Most probably, it is also related to those requests:
- crate/sqlalchemy-cratedb#92
- crate/crate-python#626

Other than this, that other patch is also related:
- GH-25

## Backlog
- [x] Software tests.
- [x] Changelog item.
- [x] Check if documentation needs to be updated.
