### PR TITLE
Types: Add method `ObjectArray.as_generic`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changelog
+- Types: Added method `ObjectArray.as_generic` for better reverse type lookups
 
 ## 2026/05/28 0.42.0
 - Added support for SQL Alchemy 2.1

--- a/src/sqlalchemy_cratedb/type/array.py
+++ b/src/sqlalchemy_cratedb/type/array.py
@@ -96,6 +96,9 @@ class Any(expression.ColumnElement):
         self.operator = operator
 
 
+# TODO: Should this be inherited from PostgreSQL's
+#       `ARRAY`, in order to improve type checking?
+#       https://github.com/crate/sqlalchemy-cratedb/issues/267
 class _ObjectArray(sqltypes.UserDefinedType):
     cache_ok = True
 
@@ -138,6 +141,9 @@ class _ObjectArray(sqltypes.UserDefinedType):
 
     def get_col_spec(self, **kws):
         return "ARRAY(OBJECT)"
+
+    def as_generic(self, **kwargs):
+        return sqltypes.ARRAY
 
 
 ObjectArray = MutableList.as_mutable(_ObjectArray)

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -20,12 +20,14 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from unittest.mock import MagicMock, patch
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import operators
+
+from sqlalchemy_cratedb import SA_1_4, SA_VERSION
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -58,6 +60,16 @@ class SqlAlchemyArrayTypeTest(TestCase):
 
     def assertSQL(self, expected_str, actual_expr):
         self.assertEqual(expected_str, str(actual_expr).replace("\n", ""))
+
+    @skipIf(SA_VERSION < SA_1_4, "`as_generic` not available with SQLAlchemy 1.3")
+    def test_as_generic(self):
+        t1 = sa.Table(
+            "t",
+            self.metadata,
+            sa.Column("int_array", sa.ARRAY(sa.Integer)),
+        )
+        array_type = t1.c.int_array.type.as_generic()
+        assert isinstance(array_type, sa.ARRAY)
 
     def test_create_with_array(self):
         t1 = sa.Table(


### PR DESCRIPTION
## About

AFAIK, this patch is needed for improved reverse type lookups, in this case for CrateDB's ARRAY type.

## References
- This is coming from a [monkeypatch to meltano-target-cratedb](https://github.com/crate-workbench/meltano-target-cratedb/blob/2b20640/target_cratedb/sqlalchemy/patch.py#L34-L37).
- It is related to GH-24.
