### PR TITLE
Types: Improve type mappings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 - Types: Added method `ObjectArray.as_generic` for better reverse type lookups
+- Types: Improved type mappings for better reverse type lookups / reflections
+  - Consequently used upper-case type definitions from `sqlalchemy.types`
+  - Added `timestamp without time zone` types (scalar and array)
+  - On SQLAlchemy 2, mapped `real` and `double{_precision}` types to the
+    newly introduced `sqltypes.{DOUBLE,DOUBLE_PRECISION}` types
 
 ## 2026/05/28 0.42.0
 - Added support for SQL Alchemy 2.1

--- a/docs/inspection-reflection.rst
+++ b/docs/inspection-reflection.rst
@@ -87,10 +87,10 @@ Create a SQLAlchemy table object:
 Reflect column data types from the table metadata:
 
     >>> table.columns.get('name')
-    Column('name', String(), table=<characters>)
+    Column('name', VARCHAR(), table=<characters>)
 
     >>> table.primary_key
-    PrimaryKeyConstraint(Column('id', String(), table=<characters>, primary_key=True...
+    PrimaryKeyConstraint(Column('id', VARCHAR(), table=<characters>, primary_key=True...
 
 
 CrateDialect

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -38,45 +38,55 @@ from .sa_version import SA_1_4, SA_2_0, SA_VERSION
 from .type import FloatVector, ObjectArray, ObjectType
 from .util import SSLMode
 
+# For SQLAlchemy >= 1.1.
 TYPES_MAP = {
-    "boolean": sqltypes.Boolean,
-    "short": sqltypes.SmallInteger,
-    "smallint": sqltypes.SmallInteger,
-    "timestamp": sqltypes.TIMESTAMP(timezone=False),
+    "boolean": sqltypes.BOOLEAN,
+    "short": sqltypes.SMALLINT,
+    "smallint": sqltypes.SMALLINT,
+    "timestamp": sqltypes.TIMESTAMP,
     "timestamp with time zone": sqltypes.TIMESTAMP(timezone=True),
+    "timestamp without time zone": sqltypes.TIMESTAMP(timezone=False),
     "object": ObjectType,
-    "integer": sqltypes.Integer,
-    "long": sqltypes.NUMERIC,
-    "bigint": sqltypes.NUMERIC,
+    "object_array": ObjectArray,  # TODO: Can this also be improved to use `sqltypes.ARRAY`?
+    "integer": sqltypes.INTEGER,
+    "long": sqltypes.BIGINT,
+    "bigint": sqltypes.BIGINT,
+    "float": sqltypes.FLOAT,
     "double": sqltypes.DECIMAL,
     "double precision": sqltypes.DECIMAL,
-    "object_array": ObjectArray,
-    "float": sqltypes.Float,
-    "real": sqltypes.Float,
-    "string": sqltypes.String,
-    "text": sqltypes.String,
+    "real": sqltypes.REAL,
+    "string": sqltypes.VARCHAR,
+    "text": sqltypes.VARCHAR,
     "float_vector": FloatVector,
 }
 
-# Needed for SQLAlchemy >= 1.1.
-# TODO: Dissolve.
+# For SQLAlchemy >= 1.4.
 try:
     from sqlalchemy.types import ARRAY
 
-    TYPES_MAP["integer_array"] = ARRAY(sqltypes.Integer)
-    TYPES_MAP["boolean_array"] = ARRAY(sqltypes.Boolean)
-    TYPES_MAP["short_array"] = ARRAY(sqltypes.SmallInteger)
-    TYPES_MAP["smallint_array"] = ARRAY(sqltypes.SmallInteger)
+    TYPES_MAP["integer_array"] = ARRAY(sqltypes.INTEGER)
+    TYPES_MAP["boolean_array"] = ARRAY(sqltypes.BOOLEAN)
+    TYPES_MAP["short_array"] = ARRAY(sqltypes.SMALLINT)
+    TYPES_MAP["smallint_array"] = ARRAY(sqltypes.SMALLINT)
     TYPES_MAP["timestamp_array"] = ARRAY(sqltypes.TIMESTAMP(timezone=False))
     TYPES_MAP["timestamp with time zone_array"] = ARRAY(sqltypes.TIMESTAMP(timezone=True))
-    TYPES_MAP["long_array"] = ARRAY(sqltypes.NUMERIC)
-    TYPES_MAP["bigint_array"] = ARRAY(sqltypes.NUMERIC)
-    TYPES_MAP["double_array"] = ARRAY(sqltypes.DECIMAL)
-    TYPES_MAP["double precision_array"] = ARRAY(sqltypes.DECIMAL)
-    TYPES_MAP["float_array"] = ARRAY(sqltypes.Float)
-    TYPES_MAP["real_array"] = ARRAY(sqltypes.Float)
-    TYPES_MAP["string_array"] = ARRAY(sqltypes.String)
-    TYPES_MAP["text_array"] = ARRAY(sqltypes.String)
+    TYPES_MAP["long_array"] = ARRAY(sqltypes.BIGINT)
+    TYPES_MAP["bigint_array"] = ARRAY(sqltypes.BIGINT)
+    TYPES_MAP["float_array"] = ARRAY(sqltypes.FLOAT)
+    TYPES_MAP["real_array"] = ARRAY(sqltypes.REAL)
+    TYPES_MAP["string_array"] = ARRAY(sqltypes.VARCHAR)
+    TYPES_MAP["text_array"] = ARRAY(sqltypes.VARCHAR)
+except Exception:  # noqa: S110
+    pass
+
+# For SQLAlchemy >= 2.0.
+try:
+    from sqlalchemy.types import DOUBLE, DOUBLE_PRECISION
+
+    TYPES_MAP["double"] = DOUBLE
+    TYPES_MAP["double_array"] = ARRAY(DOUBLE)
+    TYPES_MAP["double precision"] = DOUBLE_PRECISION
+    TYPES_MAP["double precision_array"] = ARRAY(DOUBLE_PRECISION)
 except Exception:  # noqa: S110
     pass
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -30,7 +30,7 @@ from pprint import pprint
 
 from crate.client import connect
 
-from sqlalchemy_cratedb.sa_version import SA_2_0, SA_VERSION
+from sqlalchemy_cratedb.sa_version import SA_1_4, SA_2_0, SA_VERSION
 from tests.settings import crate_host
 
 log = logging.getLogger()
@@ -179,14 +179,20 @@ def create_test_suite():
         "docs/crud.rst",
         "docs/working-with-types.rst",
         "docs/advanced-querying.rst",
-        "docs/inspection-reflection.rst",
     ]
 
-    # Don't run DataFrame integration tests on SQLAlchemy 1.3 and Python 3.7.
-    skip_dataframe = SA_VERSION < SA_2_0 or sys.version_info < (3, 8) or sys.version_info >= (3, 13)
+    # Don't run DataFrame integration tests on SQLAlchemy 1.4 and earlier, or Python 3.7.
+    skip_dataframe = SA_VERSION < SA_2_0 or sys.version_info < (3, 8)
     if not skip_dataframe:
         sqlalchemy_integration_tests += [
             "docs/dataframe.rst",
+        ]
+
+    # Don't run reflection integration tests on SQLAlchemy 1.3 and earlier and Python 3.10 and 3.11.
+    skip_reflection = SA_VERSION < SA_1_4 and (3, 10) <= sys.version_info < (3, 12)
+    if not skip_reflection:
+        sqlalchemy_integration_tests += [
+            "docs/inspection-reflection.rst",
         ]
 
     s = doctest.DocFileSuite(


### PR DESCRIPTION
## About
- Consequently use upper-case type definitions from `sqlalchemy.types`
- Add `timestamp without time zone` types (scalar and array)
- On SQLAlchemy 2, map `real` and `double{_precision}` types to the
  newly introduced `sqltypes.{DOUBLE,DOUBLE_PRECISION}` types

All of this is intended to improve reverse type lookups / reflections.

## References
- This is coming from another [monkeypatch to meltano-target-cratedb](https://github.com/crate-workbench/meltano-target-cratedb/blob/2b20640/target_cratedb/sqlalchemy/patch.py#L22-L29).
- It is related to GH-23.
- [CrateDB Toolkit's SQLAlchemy monkeypatch](https://github.com/crate/cratedb-toolkit/blob/bd132f1a0757e1454e6166fbafd19469edb55463/cratedb_toolkit/util/sqlalchemy.py).
