### PR TITLE
Types: Accept marshalling `datetime.date` values on `DateTime` fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Fixed SQL rendering of special DDL table options in `CrateDDLCompiler`.
   Before, configuring `crate_"translog.durability"` was not possible.
 - Unlocked supporting timezone-aware `DateTime` fields
+- Added support for marshalling Python `datetime.date` values on `sa.DateTime` fields
 
 ## 2024/06/13 0.37.0
 - Added support for CrateDB's [FLOAT_VECTOR] data type and its accompanying

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -115,8 +115,7 @@ class DateTime(sqltypes.DateTime):
 
     def bind_processor(self, dialect):
         def process(value):
-            if value is not None:
-                assert isinstance(value, datetime)
+            if isinstance(value, (datetime, date)):
                 return value.strftime('%Y-%m-%dT%H:%M:%S.%f%z')
             return value
         return process


### PR DESCRIPTION
## About
The test suite of `meltano-tap-cratedb`, derived from the corresponding PostgreSQL adapter, will supply `dt.date` objects. Without this patch, those will otherwise fail on this routine.

## References
- This is coming from a [monkeypatch to meltano-tap-cratedb](https://github.com/crate-workbench/meltano-tap-cratedb/blob/b1b7a6d2/tap_cratedb/patch.py#L10-L26).
- GH-22

## Backlog
- [x] Software tests.
- [x] Changelog item.
- [x] Check if documentation needs to be updated.
