### PR TITLE
Dialect: Fix `get_pk_constraint` to return `list` instead of `set` type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Added/reactivated documentation as `sqlalchemy-cratedb`
 - Added `CrateIdentifierPreparer`, in order to quote reserved words
   like `object` properly, for example when used as column names.
+- Fixed `CrateDialect.get_pk_constraint` to return `list` instead of `set` type
 
 ## 2024/06/13 0.37.0
 - Added support for CrateDB's [FLOAT_VECTOR] data type and its accompanying

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -340,7 +340,7 @@ class CrateDialect(default.DefaultDialect):
             (table_name, schema or self.default_schema_name)
         )
         pks = result_fun(pk_result)
-        return {'constrained_columns': pks,
+        return {'constrained_columns': list(sorted(pks)),
                 'name': 'PRIMARY KEY'}
 
     @reflection.cache

--- a/tests/dialect_test.py
+++ b/tests/dialect_test.py
@@ -88,7 +88,7 @@ class SqlAlchemyDialectTest(TestCase):
         )
         self.fake_cursor.fetchall = MagicMock(return_value=[["id"], ["id2"], ["id3"]])
 
-        eq_(insp.get_pk_constraint("characters")['constrained_columns'], {"id", "id2", "id3"})
+        eq_(insp.get_pk_constraint("characters")['constrained_columns'], ["id", "id2", "id3"])
         self.fake_cursor.fetchall.assert_called_once_with()
         in_("information_schema.key_column_usage", self.executed_statement)
         in_("table_catalog = ?", self.executed_statement)
@@ -103,7 +103,7 @@ class SqlAlchemyDialectTest(TestCase):
         )
         self.fake_cursor.fetchall = MagicMock(return_value=[["id"], ["id2"], ["id3"]])
 
-        eq_(insp.get_pk_constraint("characters")['constrained_columns'], {"id", "id2", "id3"})
+        eq_(insp.get_pk_constraint("characters")['constrained_columns'], ["id", "id2", "id3"])
         self.fake_cursor.fetchall.assert_called_once_with()
         in_("information_schema.key_column_usage", self.executed_statement)
         in_("table_schema = ?", self.executed_statement)


### PR DESCRIPTION
## Problem
The test suite of `meltano-tap-cratedb`, derived from the corresponding PostgreSQL adapter, will process database introspection return values by marshalling them to JSON. Because `get_pk_constraint` returns a `set` type, that will fail.
```python
TypeError: Object of type set is not JSON serializable
```

## References
This is coming from a [monkeypatch to meltano-tap-cratedb](https://github.com/crate-workbench/meltano-tap-cratedb/blob/b1b7a6d2/tap_cratedb/patch.py#L29-L49).

## Backlog
- [x] Software tests.
- [x] Changelog item.
- [x] Check if documentation needs to be updated.
