### PR TITLE
Types: Emulate PostgreSQL's `JSON(B)` types using CrateDB's `OBJECT`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
   'visit_on_conflict_do_update'` by forwarding calls to
   `PGCompiler.visit_on_conflict_do_update`
 - Dialect: Added methods concerned with isolation levels as no-ops
+- Types: Started emulating PostgreSQL's `JSON(B)` types using CrateDB's `OBJECT`
 
 ## 2026/05/28 0.42.0
 - Added support for SQL Alchemy 2.1

--- a/docs/data-types.rst
+++ b/docs/data-types.rst
@@ -51,6 +51,8 @@ CrateDB           SQLAlchemy
 `string`__        `String`__
 `array`__         `ARRAY`__
 `object`__        :ref:`object` |nbsp| (extension type)
+`object`__        ``JSON``
+`object`__        ``JSONB``
 `array(object)`__ :ref:`objectarray` |nbsp| (extension type)
 `geo_point`__     :ref:`geopoint` |nbsp| (extension type)
 `geo_shape`__     :ref:`geoshape` |nbsp| (extension type)
@@ -78,6 +80,8 @@ __ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.htm
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.String
 __ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#array
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.ARRAY
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#object
+__ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#object
 __ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#object
 __ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#array
 __ https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#geo-point

--- a/src/sqlalchemy_cratedb/compiler.py
+++ b/src/sqlalchemy_cratedb/compiler.py
@@ -271,6 +271,12 @@ class CrateTypeCompiler(compiler.GenericTypeCompiler):
         """
         return "TIMESTAMP %s" % ((type_.timezone and "WITH" or "WITHOUT") + " TIME ZONE",)
 
+    def visit_JSON(self, type_, **kw):
+        return "OBJECT"
+
+    def visit_JSONB(self, type_, **kw):
+        return "OBJECT"
+
 
 class CrateCompiler(compiler.SQLCompiler):
     def visit_getitem_binary(self, binary, operator, **kw):

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -411,7 +411,7 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
                 )
     
             """),
-            )  # noqa: W291, W293
+            )
 
             # Verify SQL DDL statement.
             self.metadata.create_all(self.engine, tables=[ItemStore.__table__], checkfirst=False)
@@ -426,7 +426,7 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
                 )
     
             """),
-            )  # noqa: W291, W293
+            )
 
         # Verify if corresponding warning is emitted.
         self.assertEqual(len(w), 1)
@@ -468,7 +468,7 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
                 )
     
             """),
-            )  # noqa: W291, W293
+            )
 
         # Verify if corresponding warning is emitted.
         self.assertEqual(len(w), 1)
@@ -510,7 +510,7 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
             )
 
         """),
-        )  # noqa: W291, W293
+        )
 
     def test_ddl_with_create_index(self):
         """
@@ -555,7 +555,7 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
             )
 
         """),
-        )  # noqa: W291, W293
+        )
 
     def test_ddl_with_jsonb_columns(self):
         from sqlalchemy.dialects.postgresql import JSONB
@@ -570,4 +570,4 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
             )
 
         """),
-        )  # noqa: W291, W293
+        )

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -556,3 +556,18 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
 
         """),
         )  # noqa: W291, W293
+
+    def test_ddl_with_jsonb_columns(self):
+        from sqlalchemy.dialects.postgresql import JSONB
+
+        mytable = sa.Table("jsonb_table", self.metadata, sa.Column("data", JSONB))
+        self.metadata.create_all(self.engine, tables=[mytable], checkfirst=False)
+        self.assertEqual(
+            self.executed_statement,
+            dedent("""
+            CREATE TABLE testdrive.jsonb_table (
+            \tdata OBJECT
+            )
+
+        """),
+        )  # noqa: W291, W293

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -543,3 +543,16 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
             "they will be omitted when generating DDL statements.",
             str(w[-1].message),
         )
+
+    def test_ddl_with_json_columns(self):
+        mytable = sa.Table("json_table", self.metadata, sa.Column("json", sa.JSON))
+        self.metadata.create_all(self.engine, tables=[mytable], checkfirst=False)
+        self.assertEqual(
+            self.executed_statement,
+            dedent("""
+            CREATE TABLE testdrive.json_table (
+            \tjson OBJECT
+            )
+
+        """),
+        )  # noqa: W291, W293


### PR DESCRIPTION
## About
The test suite of `meltano-tap-cratedb`, derived from the corresponding PostgreSQL adapter, is using PostgreSQL's `JSON` and `JSONB` types. By emulating them using CrateDB's `OBJECT` type, the corresponding test cases succeed without further ado. 💯

## References
This is coming from a [monkeypatch to meltano-tap-cratedb](https://github.com/crate-workbench/meltano-tap-cratedb/blob/b1b7a6d2/tap_cratedb/patch.py#L52-L65).

closes #215 