### PR TITLE
Documentation: Add section about migration from `crate.client`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,17 @@ pandas, Dask, and many other libraries and applications connecting to
 CrateDB from the Python ecosystem. It is verified to work with CPython, but
 it has also been tested successfully with `PyPy`_.
 
+.. note::
+
+    If you are upgrading from ``crate[sqlalchemy]`` to ``sqlalchemy-cratedb``,
+    please read this section carefully.
+
+    .. toctree::
+        :titlesonly:
+
+        migrate-from-crate-client
+
+
 
 ************
 Introduction

--- a/docs/migrate-from-crate-client.md
+++ b/docs/migrate-from-crate-client.md
@@ -1,0 +1,46 @@
+(migrate-from-crate-python)=
+# Migrate from `crate.client`
+
+In June 2024, code from the package [crate\[sqlalchemy\]] has been transferred
+to the package [sqlalchemy-cratedb]. For 80% of use cases, this will be
+a drop-in replacement with no noticeable changes.
+
+However, if you use CrateDB's special data types like `OBJECT`, `ARRAY`,
+`GEO_POINT`, or `GEO_SHAPE`, and imported the relevant symbols from
+`crate.client.sqlalchemy`, you will need to import the same symbols from
+`sqlalchemy_cratedb` from now on.
+
+## Upgrade procedure
+
+- Swap dependency definition from `crate[sqlalchemy]` to `sqlalchemy-cratedb`
+  in your `pyproject.toml`, `requirements.txt`, or `setup.py`.
+- Adjust symbol imports as outlined below.
+
+### Symbol import adjustments
+```python
+# Previous import
+# from crate.client.sqlalchemy.dialect import CrateDialect
+
+# New import
+from sqlalchemy_cratedb import dialect
+```
+
+```python
+# Previous import
+# from crate.client.sqlalchemy.types import ObjectArray, ObjectType, FloatVector, Geopoint, Geoshape
+
+# New import
+from sqlalchemy_cratedb import ObjectArray, ObjectType, FloatVector, Geopoint, Geoshape
+```
+
+```python
+# Previous import
+# from crate.client.sqlalchemy.predicates import match
+
+# New import
+from sqlalchemy_cratedb import knn_match, match
+```
+
+
+[crate\[sqlalchemy\]]: https://pypi.org/project/crate/
+[sqlalchemy-cratedb]: https://pypi.org/project/sqlalchemy-cratedb/


### PR DESCRIPTION
## Introduction
In June 2024, code from the package [crate\[sqlalchemy\]] has been transferred to the package [sqlalchemy-cratedb]. For 80% of the use cases, this will be a drop-in replacement with no noticeable changes.

## About
This patch adds a corresponding documentation section conveying a few migration notes.

## Preview
https://sqlalchemy-cratedb--135.org.readthedocs.build/migrate-from-crate-client.html

[crate\[sqlalchemy\]]: https://pypi.org/project/crate/
[sqlalchemy-cratedb]: https://pypi.org/project/sqlalchemy-cratedb/

## Trivia
_Happy to receive an acknowledgement from anyone, to be able to continue work depending on this. Thanks!_

/cc @surister, @matriv 