### PR TITLE
Support: Generalize one more use case into `support.util.refresh_table`

### DIFF
--- a/src/sqlalchemy_cratedb/support/polyfill.py
+++ b/src/sqlalchemy_cratedb/support/polyfill.py
@@ -108,10 +108,7 @@ def refresh_after_dml_engine(engine: sa.engine.Engine):
     ):
         if isinstance(clauseelement, (sa.sql.Insert, sa.sql.Update, sa.sql.Delete)):
             if not isinstance(clauseelement.table, sa.sql.Join):
-                full_table_name = f'"{clauseelement.table.name}"'
-                if clauseelement.table.schema is not None:
-                    full_table_name = f'"{clauseelement.table.schema}".' + full_table_name
-                refresh_table(conn, full_table_name)
+                refresh_table(conn, clauseelement.table)
 
     sa.event.listen(engine, "after_execute", receive_after_execute)
 

--- a/src/sqlalchemy_cratedb/support/util.py
+++ b/src/sqlalchemy_cratedb/support/util.py
@@ -10,14 +10,21 @@ if t.TYPE_CHECKING:
         pass
 
 
-def refresh_table(connection, target: t.Union[str, "DeclarativeBase"]):
+def refresh_table(connection, target: t.Union[str, "DeclarativeBase", "sa.sql.selectable.TableClause"]):
     """
     Invoke a `REFRESH TABLE` statement.
     """
-    if hasattr(target, "__tablename__"):
-        sql = f"REFRESH TABLE {target.__tablename__}"
+
+    if isinstance(target, sa.sql.selectable.TableClause):
+        full_table_name = f'"{target.name}"'
+        if target.schema is not None:
+            full_table_name = f'"{target.schema}".' + full_table_name
+    elif hasattr(target, "__tablename__"):
+        full_table_name = target.__tablename__
     else:
-        sql = f"REFRESH TABLE {target}"
+        full_table_name = target
+
+    sql = f"REFRESH TABLE {full_table_name}"
     connection.execute(sa.text(sql))
 
 


### PR DESCRIPTION
## Suggestion

@seut suggested another improvement at https://github.com/crate/sqlalchemy-cratedb/pull/28#pullrequestreview-2135990302:

> I think I'd prefer moving this quoting logic into the `refresh_table`function, by change it's signature to consume an optional schema. This would avoid that it will be called with unquoted or invalid relation names.

## Status

This patch refactors the auxiliary logic into `support.util.refresh_table`, but doesn't do anything else yet, in order not to complicate the interface too quickly/early.

## Q&A

Maybe I am currently not seeing the spot for important improvements, which should be done right from the start: So, please advise if you still would like to introduce an optional schema name as function argument, and also please suggest further improvements you would like to see in this area.
