### PR TITLE
Fixed SQL rendering of special DDL table options in `CrateDDLCompiler`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
   `check_uniqueness_factory`
 - Added `table_kwargs` context manager to enable pandas/Dask to support
   CrateDB dialect table options.
+- Fixed SQL rendering of special DDL table options in `CrateDDLCompiler`.
+  Before, configuring `crate_"translog.durability"` was not possible.
 
 ## 2024/06/13 0.37.0
 - Added support for CrateDB's [FLOAT_VECTOR] data type and its accompanying

--- a/src/sqlalchemy_cratedb/compiler.py
+++ b/src/sqlalchemy_cratedb/compiler.py
@@ -100,13 +100,13 @@ def crate_before_execute(conn, clauseelement, multiparams, params, *args, **kwar
 class CrateDDLCompiler(compiler.DDLCompiler):
 
     __special_opts_tmpl = {
-        'PARTITIONED_BY': ' PARTITIONED BY ({0})'
+        'partitioned_by': ' PARTITIONED BY ({0})'
     }
     __clustered_opts_tmpl = {
-        'NUMBER_OF_SHARDS': ' INTO {0} SHARDS',
-        'CLUSTERED_BY': ' BY ({0})',
+        'number_of_shards': ' INTO {0} SHARDS',
+        'clustered_by': ' BY ({0})',
     }
-    __clustered_opt_tmpl = ' CLUSTERED{CLUSTERED_BY}{NUMBER_OF_SHARDS}'
+    __clustered_opt_tmpl = ' CLUSTERED{clustered_by}{number_of_shards}'
 
     def get_column_specification(self, column, **kwargs):
         colspec = self.preparer.format_column(column) + " " + \
@@ -162,7 +162,7 @@ class CrateDDLCompiler(compiler.DDLCompiler):
         table_opts = []
 
         opts = dict(
-            (k[len(self.dialect.name) + 1:].upper(), v)
+            (k[len(self.dialect.name) + 1:], v)
             for k, v, in table.kwargs.items()
             if k.startswith('%s_' % self.dialect.name)
         )

--- a/tests/create_table_test.py
+++ b/tests/create_table_test.py
@@ -154,7 +154,7 @@ class SqlAlchemyCreateTableTest(TestCase):
             ('\nCREATE TABLE t (\n\t'
              'pk STRING NOT NULL, \n\t'
              'PRIMARY KEY (pk)\n'
-             ') CLUSTERED INTO 3 SHARDS WITH (NUMBER_OF_REPLICAS = 2)\n\n'),
+             ') CLUSTERED INTO 3 SHARDS WITH (number_of_replicas = 2)\n\n'),
             ())
 
     def test_table_clustered_by_and_number_of_shards(self):
@@ -173,6 +173,21 @@ class SqlAlchemyCreateTableTest(TestCase):
              'p STRING NOT NULL, \n\t'
              'PRIMARY KEY (pk, p)\n'
              ') CLUSTERED BY (p) INTO 3 SHARDS\n\n'),
+            ())
+
+    def test_table_translog_durability(self):
+        class DummyTable(self.Base):
+            __tablename__ = 't'
+            __table_args__ = {
+                'crate_"translog.durability"': "'async'",
+            }
+            pk = sa.Column(sa.String, primary_key=True)
+        self.Base.metadata.create_all(bind=self.engine)
+        fake_cursor.execute.assert_called_with(
+            ('\nCREATE TABLE t (\n\t'
+             'pk STRING NOT NULL, \n\t'
+             'PRIMARY KEY (pk)\n'
+             """) WITH ("translog.durability" = 'async')\n\n"""),
             ())
 
     def test_column_object_array(self):


### PR DESCRIPTION
## Problem
Configuring special table options like `crate_"translog.durability"` was not possible, because they got rendered into SQL DDL in uppercase letters. That fails like:

    SQLParseException[Invalid property "TRANSLOG.DURABILITY" passed to
    [ALTER | CREATE] TABLE statement]
