### PR TITLE
Add `quote_relation_name` support utility function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Changelog
 
-
 ## Unreleased
+- Added `quote_relation_name` support utility function
 
 ## 2024/06/25 0.38.0
 - Added/reactivated documentation as `sqlalchemy-cratedb`

--- a/src/sqlalchemy_cratedb/support/__init__.py
+++ b/src/sqlalchemy_cratedb/support/__init__.py
@@ -4,12 +4,13 @@ from sqlalchemy_cratedb.support.polyfill import (
     patch_autoincrement_timestamp,
     refresh_after_dml,
 )
-from sqlalchemy_cratedb.support.util import refresh_dirty, refresh_table
+from sqlalchemy_cratedb.support.util import quote_relation_name, refresh_dirty, refresh_table
 
 __all__ = [
     check_uniqueness_factory,
     insert_bulk,
     patch_autoincrement_timestamp,
+    quote_relation_name,
     refresh_after_dml,
     refresh_dirty,
     refresh_table,

--- a/tests/test_support_util.py
+++ b/tests/test_support_util.py
@@ -1,0 +1,51 @@
+import pytest
+
+from sqlalchemy_cratedb.support import quote_relation_name
+
+
+def test_quote_relation_name_once():
+    """
+    Verify quoting a simple or full-qualified relation name.
+    """
+
+    # Table name only.
+    assert quote_relation_name("my_table") == "my_table"
+    assert quote_relation_name("my-table") == '"my-table"'
+    assert quote_relation_name("MyTable") == '"MyTable"'
+    assert quote_relation_name('"MyTable"') == '"MyTable"'
+
+    # Schema and table name.
+    assert quote_relation_name("my_schema.my_table") == "my_schema.my_table"
+    assert quote_relation_name("my-schema.my_table") == '"my-schema".my_table'
+    assert quote_relation_name('"wrong-quoted-fqn.my_table"') == '"wrong-quoted-fqn.my_table"'
+    assert quote_relation_name('"my_schema"."my_table"') == '"my_schema"."my_table"'
+
+    # Catalog, schema, and table name.
+    assert quote_relation_name("crate.doc.t01") == "crate.doc.t01"
+
+
+def test_quote_relation_name_twice():
+    """
+    Verify quoting a relation name twice does not cause any harm.
+    """
+    input_fqn = "foo-bar.baz_qux"
+    output_fqn = '"foo-bar".baz_qux'
+    assert quote_relation_name(input_fqn) == output_fqn
+    assert quote_relation_name(output_fqn) == output_fqn
+
+
+def test_quote_relation_name_reserved_keywords():
+    """
+    Verify quoting a simple relation name that is a reserved keyword.
+    """
+    assert quote_relation_name("table") == '"table"'
+    assert quote_relation_name("true") == '"true"'
+    assert quote_relation_name("select") == '"select"'
+
+
+def test_quote_relation_name_with_invalid_fqn():
+    """
+    Verify quoting a relation name with an invalid fqn raises an error.
+    """
+    with pytest.raises(ValueError):
+        quote_relation_name("too-many.my-db.my-schema.my-table")


### PR DESCRIPTION
## About
The `quote_relation_name` support utility function is required in other packages than cratedb-toolkit. Because cratedb-toolkit is too heavy to be pulled into smaller packages, let's break it out of it.

## References
- https://github.com/crate/cratedb-toolkit/pull/245#pullrequestreview-2262726777

/cc @wierdvanderhaar, @hlcianfagna, @karynzv, @juanpardo, @tomach, @Taliik, @proddata 