### PR TITLE
Propagate error traces properly, using the `error_trace` `connect_args` option, by using `crate-1.0.0dev1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## Unreleased
+- Propagate error traces properly, using the `error_trace` `connect_args` option,
+  by using `crate-1.0.0dev1`
 
 ## 2024/08/29 0.39.0
-Added `quote_relation_name` support utility function
+- Added `quote_relation_name` support utility function
 
 ## 2024/06/25 0.38.0
 - Added/reactivated documentation as `sqlalchemy-cratedb`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dynamic = [
 ]
 dependencies = [
   "backports.zoneinfo<1; python_version<'3.9'",
-  "crate==1.0.0.dev0",
+  "crate==1.0.0.dev1",
   "geojson<4,>=2.5",
   "importlib-resources; python_version<'3.9'",
   "sqlalchemy<2.1,>=1",

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,21 @@
+import re
+
+import pytest
+import sqlalchemy as sa
+
+
+def test_statement_with_error_trace(cratedb_service):
+    """
+    Verify that the `error_trace` option works correctly.
+    """
+    engine = sa.create_engine(cratedb_service.database.dburi, connect_args={"error_trace": True})
+    with engine.connect() as connection:
+        with pytest.raises(sa.exc.ProgrammingError) as ex:
+            connection.execute(sa.text("CREATE TABLE foo AS SELECT 1 AS _foo"))
+        assert ex.match(
+            re.escape('InvalidColumnNameException["_foo" conflicts with system column pattern]')
+        )
+        assert ex.match(
+            "io.crate.exceptions.InvalidColumnNameException: "
+            '"_foo" conflicts with system column pattern'
+        )


### PR DESCRIPTION
## About
CrateDB's `error_trace` option has not been respected yet.

## References
- https://github.com/crate/crate-python/pull/648
