### PR TITLE
Slightly amended `do_execute...` dialect methods to store their response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Propagate error traces properly, using the `error_trace` `connect_args` option,
   by using `crate-1.0.0dev1`
+- Use slightly amended `do_execute`, `do_execute_no_params`, `do_executemany`
+  to store their responses into the request context instance
 
 ## 2024/08/29 0.39.0
 - Added `quote_relation_name` support utility function

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -233,6 +233,30 @@ class CrateDialect(default.DefaultDialect):
             return self.dbapi.connect(servers=servers, **kwargs)
         return self.dbapi.connect(**kwargs)
 
+    def do_execute(self, cursor, statement, parameters, context=None):
+        """
+        Slightly amended to store its response into the request context instance.
+        """
+        result = cursor.execute(statement, parameters)
+        if context is not None:
+            context.last_result = result
+
+    def do_execute_no_params(self, cursor, statement, context=None):
+        """
+        Slightly amended to store its response into the request context instance.
+        """
+        result = cursor.execute(statement)
+        if context is not None:
+            context.last_result = result
+
+    def do_executemany(self, cursor, statement, parameters, context=None):
+        """
+        Slightly amended to store its response into the request context instance.
+        """
+        result = cursor.executemany(statement, parameters)
+        if context is not None:
+            context.last_result = result
+
     def _get_default_schema_name(self, connection):
         return "doc"
 


### PR DESCRIPTION
## About
Make the `do_execute...` dialect methods store the last response into the request context instance, to make it available to downstream users.

## References
Code like in cratedb-toolkit will use the response/result, in this case the response from a bulk insert request, to find out about records that failed to insert.

https://github.com/crate/cratedb-toolkit/blob/v0.0.27/cratedb_toolkit/io/core.py#L141-L148
