### PR TITLE
CI: Use ubuntu-22.04 to support Python 3.7

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-22.04']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         cratedb-version: ['nightly']
         sqla-version: ['latest']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-22.04']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         cratedb-version: ['5.5.1']
         sqla-version: ['<1.4', '<1.5', '<2.1']
@@ -27,8 +27,7 @@ jobs:
 
         exclude:
           # SQLAlchemy 1.3 is not supported on Python 3.12 and higher.
-          - os: 'ubuntu-latest'
-            python-version: '3.12'
+          - python-version: '3.12'
             sqla-version: '<1.4'
 
         # Another CI test matrix slot to test against prerelease versions of Python packages.


### PR DESCRIPTION
## About
GHA updated ubuntu-latest to use Ubuntu 24.04, which apparently dropped supporting Python 3.7.

## References
- GH-164
- GH-165
