### PR TITLE
CI: Verify support on Python 3.13

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         cratedb-version: ['nightly']
         sqla-version: ['latest']
         pip-allow-prerelease: ['false']
@@ -25,7 +25,7 @@ jobs:
         # Another CI test matrix slot to test against prerelease versions of Python packages.
         include:
           - os: 'ubuntu-latest'
-            python-version: '3.12'
+            python-version: '3.13'
             cratedb-version: 'nightly'
             sqla-version: 'latest'
             pip-allow-prerelease: 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         cratedb-version: ['5.5.1']
         sqla-version: ['<1.4', '<1.5', '<2.1']
         pip-allow-prerelease: ['false']
@@ -29,11 +29,13 @@ jobs:
           # SQLAlchemy 1.3 is not supported on Python 3.12 and higher.
           - python-version: '3.12'
             sqla-version: '<1.4'
+          - python-version: '3.13'
+            sqla-version: '<1.4'
 
         # Another CI test matrix slot to test against prerelease versions of Python packages.
         include:
           - os: 'ubuntu-latest'
-            python-version: '3.12'
+            python-version: '3.13'
             cratedb-version: '5.5.1'
             sqla-version: 'latest'
             pip-allow-prerelease: 'true'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- CI: Verified support on Python 3.13
 
 ## 2024/10/07 0.40.0
 - Propagate error traces properly, using the `error_trace` `connect_args` option,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Programming Language :: SQL",
@@ -107,7 +108,7 @@ optional-dependencies.release = [
 ]
 optional-dependencies.test = [
   "cratedb-toolkit[testing]",
-  "dask[dataframe]",
+  "dask[dataframe]; python_version<'3.13'",
   "pandas<2.3",
   "pueblo>=0.0.7",
   "pytest<9",

--- a/tests/bulk_test.py
+++ b/tests/bulk_test.py
@@ -206,6 +206,7 @@ class SqlAlchemyBulkTest(TestCase):
         # Verify number of batches.
         self.assertEqual(effective_op_count, OPCOUNT)
 
+    @skipIf(sys.version_info >= (3, 13), "SQLAlchemy/Dask is not supported on Python >=3.13 yet")
     @skipIf(sys.version_info < (3, 8), "SQLAlchemy/Dask is not supported on Python <3.8")
     @skipIf(SA_VERSION < SA_2_0, "SQLAlchemy 1.4 is no longer supported by pandas 2.2")
     @patch("crate.client.connection.Cursor", mock_cursor=FakeCursor)

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -185,7 +185,7 @@ def create_test_suite():
     ]
 
     # Don't run DataFrame integration tests on SQLAlchemy 1.3 and Python 3.7.
-    skip_dataframe = SA_VERSION < SA_2_0 or sys.version_info < (3, 8)
+    skip_dataframe = SA_VERSION < SA_2_0 or sys.version_info < (3, 8) or sys.version_info >= (3, 13)
     if not skip_dataframe:
         sqlalchemy_integration_tests += [
             "docs/dataframe.rst",


### PR DESCRIPTION
## About
[Python 3.13.0](https://www.python.org/downloads/release/python-3130/) has been released on Oct. 7, 2024. This PR intends to add CI verification.

## References
- https://github.com/crate/crate-python/pull/653