### PR TITLE
Dependencies: Update to `crate-1.0.0`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - CI: Verified support on Python 3.13
+- Dependencies: Updated to `crate-1.0.0`
 
 ## 2024/10/07 0.40.0
 - Propagate error traces properly, using the `error_trace` `connect_args` option,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dynamic = [
 ]
 dependencies = [
   "backports.zoneinfo<1; python_version<'3.9'",
-  "crate==1.0.0.dev1",
+  "crate>=1.0.0.dev2,<2",
   "geojson<4,>=2.5",
   "importlib-resources; python_version<'3.9'",
   "sqlalchemy<2.1,>=1",

--- a/tests/query_caching.py
+++ b/tests/query_caching.py
@@ -24,7 +24,6 @@ from __future__ import absolute_import
 from unittest import TestCase, skipIf
 
 import sqlalchemy as sa
-from crate.testing.settings import crate_host
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.operators import eq
 
@@ -35,6 +34,8 @@ try:
     from sqlalchemy.orm import declarative_base
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
+
+from tests.settings import crate_host
 
 
 class SqlAlchemyQueryCompilationCaching(TestCase):


### PR DESCRIPTION
## About
crate-python 1.0.0 is approaching completion. This patch is one in a series that makes sure everything is in order on the downstream projects.

## References
- https://github.com/crate-workbench/langchain/issues/29
- https://github.com/crate/crash/pull/446