### PR TITLE
Update to `crate-2.0.0`, which uses `orjson` for JSON marshalling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Dependencies: Updated to `crate-2.0.0`, which uses `orjson` for JSON marshalling
 
 ## 2024/11/04 0.40.1
 - CI: Verified support on Python 3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dynamic = [
 ]
 dependencies = [
   "backports.zoneinfo<1; python_version<'3.9'",
-  "crate>=1.0.0.dev2,<2",
+  "crate>=2.0.0.dev3,<3",
   "geojson<4,>=2.5",
   "importlib-resources; python_version<'3.9'",
   "sqlalchemy<2.1,>=1",


### PR DESCRIPTION
## About
Validate and bring in an improvement to crate-python.

- https://github.com/crate/crate-python/pull/691

## References
- https://github.com/crate/cratedb-toolkit/pull/349
- https://github.com/crate/cloud-api/pull/3038
- https://github.com/crate/stevedore/pull/325