### PR TITLE
Dependencies: Update to `crate>=2.0.0.dev6`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dynamic = [
 ]
 dependencies = [
   "backports.zoneinfo<1; python_version<'3.9'",
-  "crate>=2.0.0.dev4,<3",
+  "crate>=2.0.0.dev6,<3",
   "geojson<4,>=2.5",
   "importlib-resources; python_version<'3.9'",
   "sqlalchemy<2.1,>=1",


### PR DESCRIPTION
## About
The fundamental patch GH-195 needs a little update, pulling in a more recent pre-release version of crate-python.
