### PR TITLE
Dependencies: Relax to `verlib2<0.3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
   "geojson<4,>=2.5",
   "importlib-resources; python_version<'3.9'",
   "sqlalchemy<2.1,>=1",
-  "verlib2==0.2",
+  "verlib2<0.3",
 ]
 optional-dependencies.all = [
   "sqlalchemy-cratedb[vector]",


### PR DESCRIPTION
To make GH-199 and subsequent patch release updates for verlib2 obsolete.