### PR TITLE
Dependencies: Relax version constraints on development tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ optional-dependencies.develop = [
   "poethepoet<1",
   "pyproject-fmt<3",
   "ruff<0.12",
-  "validate-pyproject<0.24",
+  "validate-pyproject<1",
 ]
 optional-dependencies.doc = [
   "crate-docs-theme>=0.26.5",


### PR DESCRIPTION
Make GH-209 obsolete.
Here: "validate-pyproject<1"
