### PR TITLE
Compiler: Make `CREATE INDEX` a no-op

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
   - Added `timestamp without time zone` types (scalar and array)
   - On SQLAlchemy 2, mapped `real` and `double{_precision}` types to the
     newly introduced `sqltypes.{DOUBLE,DOUBLE_PRECISION}` types
+- Compiler: Made `CREATE INDEX` a no-op, only emitting `SELECT 1`, because CrateDB
+  does not support that statement
 
 ## 2026/05/28 0.42.0
 - Added support for SQL Alchemy 2.1

--- a/src/sqlalchemy_cratedb/compiler.py
+++ b/src/sqlalchemy_cratedb/compiler.py
@@ -200,6 +200,17 @@ class CrateDDLCompiler(compiler.DDLCompiler):
         )
         return
 
+    def visit_create_index(self, create, **kw) -> str:
+        """
+        CrateDB does not support `CREATE INDEX` statements.
+        """
+        warnings.warn(
+            "CrateDB does not support `CREATE INDEX` statements, "
+            "they will be omitted when generating DDL statements.",
+            stacklevel=2,
+        )
+        return "SELECT 1"
+
 
 class CrateTypeCompiler(compiler.GenericTypeCompiler):
     def visit_string(self, type_, **kw):

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -511,3 +511,35 @@ class SqlAlchemyDDLCompilerTest(CompilerTestCase, ExtraAssertions):
 
         """),
         )  # noqa: W291, W293
+
+    def test_ddl_with_create_index(self):
+        """
+        Verify the CrateDB dialect properly ignores `CREATE INDEX` statements.
+        """
+
+        Base = declarative_base(metadata=self.metadata)
+
+        class FooBar(Base):
+            """The entity."""
+
+            __tablename__ = "foobar"
+
+            id = sa.Column(sa.Integer, primary_key=True)
+            name = sa.Column(sa.String, index=True)
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            # Verify SQL DDL statement.
+            self.metadata.create_all(self.engine, tables=[FooBar.__table__], checkfirst=False)
+            self.assertEqual(self.executed_statement, "SELECT 1")
+
+        # Verify if corresponding warning is emitted.
+        self.assertEqual(len(w), 1)
+        self.assertIsSubclass(w[-1].category, UserWarning)
+        self.assertIn(
+            "CrateDB does not support `CREATE INDEX` statements, "
+            "they will be omitted when generating DDL statements.",
+            str(w[-1].message),
+        )


### PR DESCRIPTION
## About
CrateDB does not understand `CREATE INDEX`.

## References
- GH-191
