### PR TITLE
Dialect: Add methods concerned with isolation levels as no-ops

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Compiler: Fixed `AttributeError: 'CrateCompilerSA20' object has no attribute
   'visit_on_conflict_do_update'` by forwarding calls to
   `PGCompiler.visit_on_conflict_do_update`
+- Dialect: Added methods concerned with isolation levels as no-ops
 
 ## 2026/05/28 0.42.0
 - Added support for SQL Alchemy 2.1

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -218,6 +218,15 @@ class CrateDialect(default.DefaultDialect):
         # start with _. Adding it here causes sqlalchemy to quote such columns.
         self.identifier_preparer.illegal_initial_characters.add("_")
 
+    def get_isolation_level_values(self, dbapi_conn):
+        return ()
+
+    def set_isolation_level(self, dbapi_connection, level):
+        pass
+
+    def get_isolation_level(self, dbapi_connection):
+        return "AUTOCOMMIT"
+
     def initialize(self, connection):
         # get lowest server version
         self.server_version_info = self._get_server_version_info(connection)

--- a/tests/dialect_test.py
+++ b/tests/dialect_test.py
@@ -150,3 +150,9 @@ class SqlAlchemyDialectTest(TestCase):
             self.executed_statement,
             "select schema_name from information_schema.schemata order by schema_name asc",
         )
+
+    def test_isolation_level(self):
+        self.engine.dialect.set_isolation_level(self.connection, "FOO")
+        assert self.engine.dialect.get_isolation_level(self.connection) == "AUTOCOMMIT"
+        assert self.engine.dialect.get_isolation_level_values(self.connection) == ()
+        self.engine.execution_options(isolation_level="AUTOCOMMIT")


### PR DESCRIPTION
## About

This was needed for unlocking [mcp-alchemy](https://github.com/runekaagaard/mcp-alchemy), because it called `set_isolation_level()` on the dialect instance.

## References
- https://github.com/crate/cratedb-examples/pull/880
