### PR TITLE
Chore: Fix test `test_statement_with_error_trace`

### DIFF
--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -11,11 +11,10 @@ def test_statement_with_error_trace(cratedb_service):
     engine = sa.create_engine(cratedb_service.database.dburi, connect_args={"error_trace": True})
     with engine.connect() as connection:
         with pytest.raises(sa.exc.ProgrammingError) as ex:
-            connection.execute(sa.text("CREATE TABLE foo AS SELECT 1 AS _foo"))
+            connection.execute(sa.text("CREATE TABLE foo AS SELECT 1 AS _id"))
+
+        # Make sure both variants match, to validate it's actually an error trace.
+        assert ex.match(re.escape('InvalidColumnNameException["_id" conflicts with system column]'))
         assert ex.match(
-            re.escape('InvalidColumnNameException["_foo" conflicts with system column pattern]')
-        )
-        assert ex.match(
-            "io.crate.exceptions.InvalidColumnNameException: "
-            '"_foo" conflicts with system column pattern'
+            'io.crate.exceptions.InvalidColumnNameException: "_id" conflicts with system column'
         )


### PR DESCRIPTION
The test case validates the `error_trace` feature. However, the offending query became valid now, so it needed to be changed.
