### PR TITLE
Compiler: Forwarding calls to `PGCompiler.visit_on_conflict_do_update`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
     newly introduced `sqltypes.{DOUBLE,DOUBLE_PRECISION}` types
 - Compiler: Made `CREATE INDEX` a no-op, only emitting `SELECT 1`, because CrateDB
   does not support that statement
+- Compiler: Fixed `AttributeError: 'CrateCompilerSA20' object has no attribute
+  'visit_on_conflict_do_update'` by forwarding calls to
+  `PGCompiler.visit_on_conflict_do_update`
 
 ## 2026/05/28 0.42.0
 - Added support for SQL Alchemy 2.1

--- a/src/sqlalchemy_cratedb/compiler.py
+++ b/src/sqlalchemy_cratedb/compiler.py
@@ -213,6 +213,9 @@ class CrateDDLCompiler(compiler.DDLCompiler):
 
 
 class CrateTypeCompiler(compiler.GenericTypeCompiler):
+    visit_on_conflict_do_update = PGCompiler.visit_on_conflict_do_update
+    _on_conflict_target = PGCompiler._on_conflict_target
+
     def visit_string(self, type_, **kw):
         return "STRING"
 


### PR DESCRIPTION
## Problem
```python
AttributeError: 'CrateCompilerSA20' object has no attribute 'visit_on_conflict_do_update'
```

## References
- GH-186