### PR TITLE
Migrate to `paramstyle="pyformat"`, following crate-python 2.2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         cratedb-version: ['nightly']
         sqla-version: ['<1.4', '<1.5', '<2.1', '<2.2']
         pip-allow-prerelease: ['false']
@@ -33,12 +33,6 @@ jobs:
             sqla-version: '<1.4'
           - python-version: '3.14'
             sqla-version: '<1.4'
-
-          # SQLAlchemy 2.1 requires Python 3.9+.
-          - python-version: '3.7'
-            sqla-version: '<2.2'
-          - python-version: '3.8'
-            sqla-version: '<2.2'
 
         # Another CI test matrix slot to test against prerelease versions of Python packages.
         include:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Changelog
+- Migrated to `paramstyle="pyformat"`, following crate-python 2.2.0
 
 ## 2026/05/28 0.42.0
 - Added support for SQL Alchemy 2.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,28 @@
   'visit_on_conflict_do_update'` by forwarding calls to
   `PGCompiler.visit_on_conflict_do_update`
 - Dialect: Added methods concerned with isolation levels as no-ops
-- Migrated to `paramstyle="pyformat"`, following crate-python 2.2.0
+- Migrated to `paramstyle="pyformat"`, following crate-python 2.2.1.
+
+  **Breaking change:** The dialect now generates `%(name)s` named placeholders
+  and passes a `dict` of parameters to the DBAPI cursor, instead of the previous
+  `?` positional placeholders with a `tuple`. crate-python converts these to
+  CrateDB's native `$N` positional markers before sending over HTTP, so no
+  server-side changes are required.
+
+  User impact:
+
+  - **ORM / Core users**: No action required. SQLAlchemy handles parameter
+    binding transparently; existing application code continues to work unchanged.
+  - **Direct cursor users** who log or inspect the SQL string passed to
+    `cursor.execute()` will observe `%(name)s` placeholders instead of `?`.
+  - **Partial `ObjectType` updates** generate subscript-assignment SQL with named
+    parameters, e.g. `SET data['x'] = %(data_'x'_)s`, replacing the previous
+    positional form `SET data['x'] = ?`.
+  - **`pandas` / Dask `DataFrame.to_sql(..., method=insert_bulk)`** continues to
+    work. The bulk-operations path sends `$N` positional SQL to CrateDB, with
+    conversion handled by crate-python ≥ 2.2.1.
+  - **Minimum Python version raised to 3.10.** crate-python 2.1.0+ requires
+    Python ≥ 3.10. Python 3.6–3.9 are no longer supported.
 
 ## 2026/05/28 0.42.0
 - Added support for SQL Alchemy 2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dynamic = [
 ]
 dependencies = [
   "backports.zoneinfo<1; python_version<'3.9'",
-  "crate>=2.2.1b3,<3",
+  "crate>=2.2.1,<3",
   "geojson>=2.5,<4",
   "importlib-metadata; python_version<'3.8'",
   "importlib-resources; python_version<'3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dynamic = [
 ]
 dependencies = [
   "backports.zoneinfo<1; python_version<'3.9'",
-  "crate>=2.2.1b2,<3",
+  "crate>=2.2.1b3,<3",
   "geojson>=2.5,<4",
   "importlib-metadata; python_version<'3.8'",
   "importlib-resources; python_version<'3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dynamic = [
 ]
 dependencies = [
   "backports.zoneinfo<1; python_version<'3.9'",
-  "crate>=2.2.1b1,<3",
+  "crate>=2.2.1b2,<3",
   "geojson>=2.5,<4",
   "importlib-metadata; python_version<'3.8'",
   "importlib-resources; python_version<'3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dynamic = [
 ]
 dependencies = [
   "backports.zoneinfo<1; python_version<'3.9'",
-  "crate>=2,<3",
+  "crate>=2.2.1b1,<3",
   "geojson>=2.5,<4",
   "importlib-metadata; python_version<'3.8'",
   "importlib-resources; python_version<'3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ license = { text = "Apache License 2.0" }
 authors = [
   { name = "Crate.io", email = "office@crate.io" },
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Plugins",
@@ -43,10 +43,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/src/sqlalchemy_cratedb/dialect.py
+++ b/src/sqlalchemy_cratedb/dialect.py
@@ -180,7 +180,7 @@ else:
 class CrateDialect(default.DefaultDialect):
     name = "crate"
     driver = "crate-python"
-    default_paramstyle = "qmark"
+    default_paramstyle = "pyformat"
     statement_compiler = statement_compiler
     ddl_compiler = CrateDDLCompiler
     type_compiler = CrateTypeCompiler

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -69,7 +69,7 @@ class SqlAlchemyArrayTypeTest(TestCase):
         t1.create(self.engine)
         fake_cursor.execute.assert_called_with(
             ("\nCREATE TABLE t (\n\tint_array ARRAY(INT), \n\tstr_array ARRAY(STRING)\n)\n\n"),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_array_insert(self):
@@ -77,21 +77,27 @@ class SqlAlchemyArrayTypeTest(TestCase):
         self.session.add(trillian)
         self.session.commit()
         fake_cursor.execute.assert_called_with(
-            ("INSERT INTO users (name, friends, scores) VALUES (?, ?, ?)"),
-            ("Trillian", ["Arthur", "Ford"], None),
+            (
+                "INSERT INTO users (name, friends, scores) "
+                "VALUES (%(name)s, %(friends)s, %(scores)s)"
+            ),
+            {"friends": ["Arthur", "Ford"], "name": "Trillian", "scores": None},
         )
 
     def test_any(self):
         s = self.session.query(self.User.name).filter(self.User.friends.any("arthur"))
         self.assertSQL(
-            "SELECT users.name AS users_name FROM users WHERE ? = ANY (users.friends)", s
+            "SELECT users.name AS users_name FROM users WHERE %(friends_1)s = ANY (users.friends)",
+            s,
         )
 
     def test_any_with_operator(self):
         s = self.session.query(self.User.name).filter(
             self.User.scores.any(6, operator=operators.lt)
         )
-        self.assertSQL("SELECT users.name AS users_name FROM users WHERE ? < ANY (users.scores)", s)
+        self.assertSQL(
+            "SELECT users.name AS users_name FROM users WHERE %(scores_1)s < ANY (users.scores)", s
+        )
 
     def test_multidimensional_arrays(self):
         t1 = sa.Table(

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -98,18 +98,33 @@ class SqlAlchemyArrayTypeTest(TestCase):
 
     def test_any(self):
         s = self.session.query(self.User.name).filter(self.User.friends.any("arthur"))
-        self.assertSQL(
-            "SELECT users.name AS users_name FROM users WHERE %(friends_1)s = ANY (users.friends)",
-            s,
-        )
+        # SA 1.4+ uses the column name as the bind param name; SA 1.3 uses a generic "param_1".
+        if SA_VERSION >= SA_1_4:
+            self.assertSQL(
+                "SELECT users.name AS users_name FROM users WHERE %(friends_1)s = ANY (users.friends)",
+                s,
+            )
+        else:
+            self.assertSQL(
+                "SELECT users.name AS users_name FROM users WHERE %(param_1)s = ANY (users.friends)",
+                s,
+            )
 
     def test_any_with_operator(self):
         s = self.session.query(self.User.name).filter(
             self.User.scores.any(6, operator=operators.lt)
         )
-        self.assertSQL(
-            "SELECT users.name AS users_name FROM users WHERE %(scores_1)s < ANY (users.scores)", s
-        )
+        # SA 1.4+ uses the column name as the bind param name; SA 1.3 uses a generic "param_1".
+        if SA_VERSION >= SA_1_4:
+            self.assertSQL(
+                "SELECT users.name AS users_name FROM users WHERE %(scores_1)s < ANY (users.scores)",
+                s,
+            )
+        else:
+            self.assertSQL(
+                "SELECT users.name AS users_name FROM users WHERE %(param_1)s < ANY (users.scores)",
+                s,
+            )
 
     def test_multidimensional_arrays(self):
         t1 = sa.Table(

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -101,8 +101,7 @@ class SqlAlchemyArrayTypeTest(TestCase):
         # SA 1.4+ uses the column name as the bind param; SA 1.3 uses a generic "param_1".
         param = "friends_1" if SA_VERSION >= SA_1_4 else "param_1"
         self.assertSQL(
-            "SELECT users.name AS users_name FROM users "
-            f"WHERE %({param})s = ANY (users.friends)",
+            f"SELECT users.name AS users_name FROM users WHERE %({param})s = ANY (users.friends)",
             s,
         )
 
@@ -113,8 +112,7 @@ class SqlAlchemyArrayTypeTest(TestCase):
         # SA 1.4+ uses the column name as the bind param; SA 1.3 uses a generic "param_1".
         param = "scores_1" if SA_VERSION >= SA_1_4 else "param_1"
         self.assertSQL(
-            "SELECT users.name AS users_name FROM users "
-            f"WHERE %({param})s < ANY (users.scores)",
+            f"SELECT users.name AS users_name FROM users WHERE %({param})s < ANY (users.scores)",
             s,
         )
 

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -98,33 +98,25 @@ class SqlAlchemyArrayTypeTest(TestCase):
 
     def test_any(self):
         s = self.session.query(self.User.name).filter(self.User.friends.any("arthur"))
-        # SA 1.4+ uses the column name as the bind param name; SA 1.3 uses a generic "param_1".
-        if SA_VERSION >= SA_1_4:
-            self.assertSQL(
-                "SELECT users.name AS users_name FROM users WHERE %(friends_1)s = ANY (users.friends)",
-                s,
-            )
-        else:
-            self.assertSQL(
-                "SELECT users.name AS users_name FROM users WHERE %(param_1)s = ANY (users.friends)",
-                s,
-            )
+        # SA 1.4+ uses the column name as the bind param; SA 1.3 uses a generic "param_1".
+        param = "friends_1" if SA_VERSION >= SA_1_4 else "param_1"
+        self.assertSQL(
+            "SELECT users.name AS users_name FROM users "
+            f"WHERE %({param})s = ANY (users.friends)",
+            s,
+        )
 
     def test_any_with_operator(self):
         s = self.session.query(self.User.name).filter(
             self.User.scores.any(6, operator=operators.lt)
         )
-        # SA 1.4+ uses the column name as the bind param name; SA 1.3 uses a generic "param_1".
-        if SA_VERSION >= SA_1_4:
-            self.assertSQL(
-                "SELECT users.name AS users_name FROM users WHERE %(scores_1)s < ANY (users.scores)",
-                s,
-            )
-        else:
-            self.assertSQL(
-                "SELECT users.name AS users_name FROM users WHERE %(param_1)s < ANY (users.scores)",
-                s,
-            )
+        # SA 1.4+ uses the column name as the bind param; SA 1.3 uses a generic "param_1".
+        param = "scores_1" if SA_VERSION >= SA_1_4 else "param_1"
+        self.assertSQL(
+            "SELECT users.name AS users_name FROM users "
+            f"WHERE %({param})s < ANY (users.scores)",
+            s,
+        )
 
     def test_multidimensional_arrays(self):
         t1 = sa.Table(

--- a/tests/bulk_test.py
+++ b/tests/bulk_test.py
@@ -108,6 +108,53 @@ class SqlAlchemyBulkTest(TestCase):
         )
         self.assertSequenceEqual(expected_bulk_args, bulk_args)
 
+    @skipIf(SA_VERSION >= SA_2_0, "SQLAlchemy 2.x uses modern bulk INSERT mode")
+    def test_executemany_pyformat_dicts_arrive_positional_at_client(self):
+        """
+        Verify the full pipeline for legacy bulk INSERT:
+          SA generates %(name)s SQL + dict rows  →  cursor.executemany()
+          →  crate-python _convert_named_bulk_params()
+          →  Client.sql() receives $N SQL + list-of-lists bulk_parameters
+
+        test_bulk_save_legacy uses FakeCursor and only verifies what SA passes
+        to the cursor interface.  This test patches Client.sql instead, letting
+        the real cursor code run, and asserts the wire-format conversion.
+        """
+        chars = [
+            self.character(name="Arthur", age=35),
+            self.character(name="Banshee", age=26),
+            self.character(name="Callisto", age=37),
+        ]
+
+        with patch(
+            "crate.client.http.Client.sql",
+            autospec=True,
+            return_value={
+                "cols": [],
+                "rows": [],
+                "rowcount": -1,
+                "results": [{"rowcount": 1}, {"rowcount": 1}, {"rowcount": 1}],
+                "duration": 0,
+            },
+        ) as client_mock:
+            self.session.bulk_save_objects(chars)
+
+        self.assertTrue(client_mock.called, "Client.sql was never called")
+        _self_arg, stmt, parameters, bulk_parameters = client_mock.call_args[0]
+
+        # crate-python must have converted %(name)s → $N before sending
+        self.assertNotIn("%(", stmt, f"stmt still contains %(name)s placeholders: {stmt!r}")
+        self.assertRegex(stmt, r"\$\d", f"stmt should contain $N positional markers: {stmt!r}")
+
+        # parameters (single-row) must be None for a bulk call
+        self.assertIsNone(parameters)
+
+        # bulk_parameters must be a list of positional lists, not dicts
+        self.assertIsInstance(bulk_parameters, list)
+        self.assertEqual(len(bulk_parameters), 3)
+        for row in bulk_parameters:
+            self.assertIsInstance(row, list, f"expected positional list, got {type(row)}: {row!r}")
+
     @skipIf(SA_VERSION < SA_2_0, "SQLAlchemy 1.x uses legacy bulk INSERT mode")
     @patch("crate.client.connection.Cursor", FakeCursor)
     def test_bulk_save_modern(self):

--- a/tests/bulk_test.py
+++ b/tests/bulk_test.py
@@ -98,10 +98,14 @@ class SqlAlchemyBulkTest(TestCase):
         self.session.bulk_save_objects(chars)
         (stmt, bulk_args), _ = fake_cursor.executemany.call_args
 
-        expected_stmt = "INSERT INTO characters (name, age) VALUES (?, ?)"
+        expected_stmt = "INSERT INTO characters (name, age) VALUES (%(name)s, %(age)s)"
         self.assertEqual(expected_stmt, stmt)
 
-        expected_bulk_args = (("Arthur", 35), ("Banshee", 26), ("Callisto", 37))
+        expected_bulk_args = (
+            {"age": 35, "name": "Arthur"},
+            {"age": 26, "name": "Banshee"},
+            {"age": 37, "name": "Callisto"},
+        )
         self.assertSequenceEqual(expected_bulk_args, bulk_args)
 
     @skipIf(SA_VERSION < SA_2_0, "SQLAlchemy 1.x uses legacy bulk INSERT mode")
@@ -153,17 +157,20 @@ class SqlAlchemyBulkTest(TestCase):
         self.session.commit()
         (stmt, bulk_args), _ = fake_cursor.execute.call_args
 
-        expected_stmt = "INSERT INTO characters (name, age) VALUES (?, ?), (?, ?), (?, ?)"
+        expected_stmt = (
+            "INSERT INTO characters (name, age) "
+            "VALUES (%(name__0)s, %(age__0)s), (%(name__1)s, %(age__1)s), (%(name__2)s, %(age__2)s)"
+        )
         self.assertEqual(expected_stmt, stmt)
 
-        expected_bulk_args = (
-            "Arthur",
-            35,
-            "Banshee",
-            26,
-            "Callisto",
-            37,
-        )
+        expected_bulk_args = {
+            "age__0": 35,
+            "name__0": "Arthur",
+            "age__1": 26,
+            "name__1": "Banshee",
+            "age__2": 37,
+            "name__2": "Callisto",
+        }
         self.assertSequenceEqual(expected_bulk_args, bulk_args)
 
     @skipIf(sys.version_info < (3, 8), "SQLAlchemy/pandas is not supported on Python <3.8")

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -97,7 +97,7 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
                 dedent("""
                 SELECT mytable.name, mytable.data 
                 FROM mytable 
-                WHERE mytable.name ILIKE ?
+                WHERE mytable.name ILIKE %(name_1)s
             """).strip(),
             )  # noqa: W291
         else:
@@ -106,7 +106,7 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
                 dedent("""
                 SELECT mytable.name, mytable.data 
                 FROM mytable 
-                WHERE lower(mytable.name) LIKE lower(?)
+                WHERE lower(mytable.name) LIKE lower(%(name_1)s)
             """).strip(),
             )  # noqa: W291
 
@@ -122,7 +122,7 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
                 dedent("""
                 SELECT mytable.name, mytable.data 
                 FROM mytable 
-                WHERE lower(mytable.name) NOT LIKE lower(?)
+                WHERE lower(mytable.name) NOT LIKE lower(%(name_1)s)
             """).strip(),
             )  # noqa: W291
         else:
@@ -131,7 +131,7 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
                 dedent("""
                 SELECT mytable.name, mytable.data 
                 FROM mytable 
-                WHERE mytable.name NOT ILIKE ?
+                WHERE mytable.name NOT ILIKE %(name_1)s
             """).strip(),
             )  # noqa: W291
 
@@ -167,11 +167,13 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
         statement = str(selectable.compile(bind=self.crate_engine))
         if SA_VERSION >= SA_1_4:
             self.assertEqual(
-                statement, "SELECT mytable.name, mytable.data \nFROM mytable\n LIMIT ALL OFFSET ?"
+                statement,
+                "SELECT mytable.name, mytable.data \nFROM mytable\n LIMIT ALL OFFSET %(param_1)s",
             )
         else:
             self.assertEqual(
-                statement, "SELECT mytable.name, mytable.data \nFROM mytable \n LIMIT ALL OFFSET ?"
+                statement,
+                "SELECT mytable.name, mytable.data \nFROM mytable \n LIMIT ALL OFFSET %(param_1)s",
             )
 
     def test_select_with_limit(self):
@@ -180,7 +182,9 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
         """
         selectable = self.mytable.select().limit(42)
         statement = str(selectable.compile(bind=self.crate_engine))
-        self.assertEqual(statement, "SELECT mytable.name, mytable.data \nFROM mytable \n LIMIT ?")
+        self.assertEqual(
+            statement, "SELECT mytable.name, mytable.data \nFROM mytable \n LIMIT %(param_1)s"
+        )
 
     def test_select_with_offset_and_limit(self):
         """
@@ -189,7 +193,9 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
         selectable = self.mytable.select().offset(5).limit(42)
         statement = str(selectable.compile(bind=self.crate_engine))
         self.assertEqual(
-            statement, "SELECT mytable.name, mytable.data \nFROM mytable \n LIMIT ? OFFSET ?"
+            statement,
+            "SELECT mytable.name, mytable.data \n"
+            "FROM mytable \n LIMIT %(param_1)s OFFSET %(param_2)s",
         )
 
     def test_insert_multivalues(self):
@@ -220,7 +226,10 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
         records = [{"name": f"foo_{i}"} for i in range(3)]
         insertable = self.mytable.insert().values(records)
         statement = str(insertable.compile(bind=self.crate_engine))
-        self.assertEqual(statement, "INSERT INTO mytable (name) VALUES (?), (?), (?)")
+        self.assertEqual(
+            statement,
+            "INSERT INTO mytable (name) VALUES (%(name_m0)s), (%(name_m1)s), (%(name_m2)s)",
+        )
 
     @skipIf(
         SA_VERSION < SA_2_0,
@@ -263,7 +272,7 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
         records = [{"name": f"foo_{i}"} for i in range(record_count)]
         insertable = self.mytable.insert()
         statement = str(insertable.compile(bind=self.crate_engine))
-        self.assertEqual(statement, "INSERT INTO mytable (name, data) VALUES (?, ?)")
+        self.assertEqual(statement, "INSERT INTO mytable (name, data) VALUES (%(name)s, %(data)s)")
 
         with mock.patch(
             "crate.client.http.Client.sql", autospec=True, return_value={"cols": []}
@@ -278,12 +287,18 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
             client_mock.mock_calls,
             [
                 mock.call(
-                    mock.ANY, "INSERT INTO mytable (name) VALUES (?), (?)", ("foo_0", "foo_1"), None
+                    mock.ANY,
+                    "INSERT INTO mytable (name) VALUES ($1), ($2)",
+                    ["foo_0", "foo_1"],
+                    None,
                 ),
                 mock.call(
-                    mock.ANY, "INSERT INTO mytable (name) VALUES (?), (?)", ("foo_2", "foo_3"), None
+                    mock.ANY,
+                    "INSERT INTO mytable (name) VALUES ($1), ($2)",
+                    ["foo_2", "foo_3"],
+                    None,
                 ),
-                mock.call(mock.ANY, "INSERT INTO mytable (name) VALUES (?)", ("foo_4",), None),
+                mock.call(mock.ANY, "INSERT INTO mytable (name) VALUES ($1)", ["foo_4"], None),
             ],
         )
 

--- a/tests/create_table_test.py
+++ b/tests/create_table_test.py
@@ -75,7 +75,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "\n\tdouble_col DOUBLE, "
                 "\n\tPRIMARY KEY (string_col)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_obj(self):
@@ -90,7 +90,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "\nCREATE TABLE dummy (\n\tpk STRING NOT NULL, \n\tobj_col OBJECT, "
                 "\n\tPRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_table_clustered_by(self):
@@ -109,7 +109,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "PRIMARY KEY (pk)\n"
                 ") CLUSTERED BY (p)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_computed(self):
@@ -127,7 +127,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "PRIMARY KEY (ts)\n"
                 ")\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_computed_virtual(self):
@@ -155,7 +155,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "PRIMARY KEY (pk)\n"
                 ") PARTITIONED BY (p)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_table_number_of_shards_and_replicas(self):
@@ -172,7 +172,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "PRIMARY KEY (pk)\n"
                 ") CLUSTERED INTO 3 SHARDS WITH (number_of_replicas = 2)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_table_clustered_by_and_number_of_shards(self):
@@ -191,7 +191,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "PRIMARY KEY (pk, p)\n"
                 ") CLUSTERED BY (p) INTO 3 SHARDS\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_table_translog_durability(self):
@@ -210,7 +210,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "PRIMARY KEY (pk)\n"
                 """) WITH ("translog.durability" = 'async')\n\n"""
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_object_array(self):
@@ -227,7 +227,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "tags ARRAY(OBJECT), \n\t"
                 "PRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_nullable(self):
@@ -246,7 +246,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "b INT NOT NULL, \n\t"
                 "PRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_pk_nullable(self):
@@ -273,7 +273,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "b INT, \n\t"
                 "PRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     @pytest.mark.skip("CompileError not raised")
@@ -305,7 +305,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "c STRING, \n\t"
                 "PRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_non_text_column_without_columnstore(self):
@@ -331,7 +331,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "a TIMESTAMP WITHOUT TIME ZONE DEFAULT now(), \n\t"
                 "PRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_server_default_string(self):
@@ -348,7 +348,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "a STRING DEFAULT 'Zaphod', \n\t"
                 "PRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_server_default_func(self):
@@ -365,7 +365,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "a TIMESTAMP WITHOUT TIME ZONE DEFAULT now(), \n\t"
                 "PRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_column_server_default_text_constant(self):
@@ -382,7 +382,7 @@ class SqlAlchemyCreateTableTest(TestCase):
                 "answer INT DEFAULT 42, \n\t"
                 "PRIMARY KEY (pk)\n)\n\n"
             ),
-            (),
+            sa.util.immutabledict({}),
         )
 
     @skipIf(SA_VERSION < SA_2_0, "sa.Double was introduced in SA 2.0")

--- a/tests/dialect_test.py
+++ b/tests/dialect_test.py
@@ -156,3 +156,10 @@ class SqlAlchemyDialectTest(TestCase):
         assert self.engine.dialect.get_isolation_level(self.connection) == "AUTOCOMMIT"
         assert self.engine.dialect.get_isolation_level_values(self.connection) == ()
         self.engine.execution_options(isolation_level="AUTOCOMMIT")
+        
+    def test_default_paramstyle_is_pyformat(self):
+        """
+        Verify CrateDialect.default_paramstyle must be "pyformat" 
+        so that SQLAlchemy generates %(name)s placeholders.
+        """
+        eq_(self.engine.dialect.default_paramstyle, "pyformat")

--- a/tests/dialect_test.py
+++ b/tests/dialect_test.py
@@ -156,10 +156,10 @@ class SqlAlchemyDialectTest(TestCase):
         assert self.engine.dialect.get_isolation_level(self.connection) == "AUTOCOMMIT"
         assert self.engine.dialect.get_isolation_level_values(self.connection) == ()
         self.engine.execution_options(isolation_level="AUTOCOMMIT")
-        
+
     def test_default_paramstyle_is_pyformat(self):
         """
-        Verify CrateDialect.default_paramstyle must be "pyformat" 
+        Verify CrateDialect.default_paramstyle must be "pyformat"
         so that SQLAlchemy generates %(name)s placeholders.
         """
         eq_(self.engine.dialect.default_paramstyle, "pyformat")

--- a/tests/dict_test.py
+++ b/tests/dict_test.py
@@ -69,18 +69,20 @@ class SqlAlchemyDictTypeTest(TestCase):
     def test_select_with_dict_column_where_clause(self):
         mytable = self.mytable
         s = select(mytable.c.data).where(mytable.c.data["x"] == 1)
-        self.assertSQL("SELECT mytable.data FROM mytable WHERE mytable.data['x'] = ?", s)
+        self.assertSQL("SELECT mytable.data FROM mytable WHERE mytable.data['x'] = %(param_1)s", s)
 
     def test_select_with_dict_column_nested_where(self):
         mytable = self.mytable
         s = select(mytable.c.name)
         s = s.where(mytable.c.data["x"]["y"] == 1)
-        self.assertSQL("SELECT mytable.name FROM mytable " + "WHERE mytable.data['x']['y'] = ?", s)
+        self.assertSQL(
+            "SELECT mytable.name FROM mytable " + "WHERE mytable.data['x']['y'] = %(param_1)s", s
+        )
 
     def test_select_with_dict_column_where_clause_gt(self):
         mytable = self.mytable
         s = select(mytable.c.data).where(mytable.c.data["x"] > 1)
-        self.assertSQL("SELECT mytable.data FROM mytable WHERE mytable.data['x'] > ?", s)
+        self.assertSQL("SELECT mytable.data FROM mytable WHERE mytable.data['x'] > %(param_1)s", s)
 
     def test_select_with_dict_column_where_clause_other_col(self):
         mytable = self.mytable
@@ -97,7 +99,9 @@ class SqlAlchemyDictTypeTest(TestCase):
             .where(mytable.c.name == "Arthur Dent")
             .values({"data['x']": "Trillian"})
         )
-        self.assertSQL("UPDATE mytable SET data['x'] = ? WHERE mytable.name = ?", stmt)
+        self.assertSQL(
+            "UPDATE mytable SET data['x'] = %(data_'x'_)s WHERE mytable.name = %(name_1)s", stmt
+        )
 
     def set_up_character_and_cursor(self, return_value=None):
         """
@@ -200,11 +204,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            "UPDATE characters SET data = ? WHERE characters.name = ?",
-            (
-                {"x": 1},
-                "Trillian",
-            ),
+            "UPDATE characters SET data = %(data)s WHERE characters.name = %(characters_name)s",
+            {
+                "characters_name": "Trillian",
+                "data": {"x": 1},
+            },
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -243,13 +247,19 @@ class SqlAlchemyDictTypeTest(TestCase):
         # first isn't deterministic
         try:
             fake_cursor.execute.assert_called_with(
-                ("UPDATE characters SET data['y'] = ?, data['x'] = ? WHERE characters.name = ?"),
+                (
+                    "UPDATE characters SET data['y'] = %(data_'y'_)s, data['x'] = %(data_'x'_)s "
+                    "WHERE characters.name = %(characters_name)s"
+                ),
                 (2, 1, "Trillian"),
             )
         except AssertionError:
             fake_cursor.execute.assert_called_with(
-                ("UPDATE characters SET data['x'] = ?, data['y'] = ? WHERE characters.name = ?"),
-                (1, 2, "Trillian"),
+                (
+                    "UPDATE characters SET data['x'] = %(data_'x'_)s, data['y'] = %(data_'y'_)s "
+                    "WHERE characters.name = %(characters_name)s"
+                ),
+                {"characters_name": "Trillian", "data_'x'_": 1, "data_'y'_": 2},
             )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -270,7 +280,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         char.data["y"] = 3
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data['y'] = ? WHERE characters.name = ?"), (3, "Trillian")
+            (
+                "UPDATE characters SET data['y'] = %(data_'y'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_'y'_": 3},
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -284,8 +298,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         char.age = 20
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET age = ?, data['x'] = ? WHERE characters.name = ?"),
-            (20, 1, "Trillian"),
+            (
+                "UPDATE characters SET age = %(age)s, data['x'] = %(data_'x'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"age": 20, "characters_name": "Trillian", "data_'x'_": 1},
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -300,7 +317,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data['x'] = ? WHERE characters.name = ?"), (None, "Trillian")
+            (
+                "UPDATE characters SET data['x'] = %(data_'x'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_'x'_": None},
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -321,7 +342,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data['x'] = ? WHERE characters.name = ?"), (4, "Trillian")
+            (
+                "UPDATE characters SET data['x'] = %(data_'x'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_'x'_": 4},
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -341,7 +366,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data['x'] = ? WHERE characters.name = ?"), (None, "Trillian")
+            (
+                "UPDATE characters SET data['x'] = %(data_'x'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_'x'_": None},
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -362,7 +391,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data['x'] = ? WHERE characters.name = ?"), (3, "Trillian")
+            (
+                "UPDATE characters SET data['x'] = %(data_'x'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_'x'_": 3},
         )
 
     def set_up_character_and_cursor_data_list(self, return_value=None):
@@ -402,8 +435,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data_list = ? WHERE characters.name = ?"),
-            ([{"1": 1}, {"3": 3}], "Trillian"),
+            (
+                "UPDATE characters SET data_list = %(data_list)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_list": [{"1": 1}, {"3": 3}]},
         )
 
     def _setup_nested_object_char(self):
@@ -423,8 +459,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data['nested'] = ? WHERE characters.name = ?"),
-            ({"y": {"z": 2}, "x": 3}, "Trillian"),
+            (
+                "UPDATE characters SET data['nested'] = %(data_'nested'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_'nested'_": {"y": {"z": 2}, "x": 3}},
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -435,8 +474,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data['nested'] = ? WHERE characters.name = ?"),
-            ({"y": {"z": 5}, "x": 1}, "Trillian"),
+            (
+                "UPDATE characters SET data['nested'] = %(data_'nested'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_'nested'_": {"y": {"z": 5}, "x": 1}},
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)
@@ -447,8 +489,11 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
-            ("UPDATE characters SET data['nested'] = ? WHERE characters.name = ?"),
-            ({"y": {}, "x": 1}, "Trillian"),
+            (
+                "UPDATE characters SET data['nested'] = %(data_'nested'_)s "
+                "WHERE characters.name = %(characters_name)s"
+            ),
+            {"characters_name": "Trillian", "data_'nested'_": {"y": {}, "x": 1}},
         )
 
     @patch("crate.client.connection.Cursor", FakeCursor)

--- a/tests/dict_test.py
+++ b/tests/dict_test.py
@@ -251,7 +251,7 @@ class SqlAlchemyDictTypeTest(TestCase):
                     "UPDATE characters SET data['y'] = %(data_'y'_)s, data['x'] = %(data_'x'_)s "
                     "WHERE characters.name = %(characters_name)s"
                 ),
-                (2, 1, "Trillian"),
+                {"characters_name": "Trillian", "data_'y'_": 2, "data_'x'_": 1},
             )
         except AssertionError:
             fake_cursor.execute.assert_called_with(

--- a/tests/insert_from_select_test.py
+++ b/tests/insert_from_select_test.py
@@ -83,6 +83,7 @@ class SqlAlchemyInsertFromSelectTest(TestCase):
         self.session.commit()
         self.assertSQL(
             "INSERT INTO characters_archive (name, age) "
-            "SELECT characters.name, characters.age FROM characters WHERE characters.status = ?",
+            "SELECT characters.name, characters.age FROM characters "
+            "WHERE characters.status = %(status_1)s",
             ins.compile(bind=self.engine),
         )

--- a/tests/match_test.py
+++ b/tests/match_test.py
@@ -71,7 +71,7 @@ class SqlAlchemyMatchTest(TestCase):
         )
         self.assertSQL(
             "SELECT characters.name AS characters_name FROM characters "
-            + "WHERE match(characters.name, ?)",
+            + "WHERE match(characters.name, %(param_1)s)",
             query,
         )
 
@@ -81,7 +81,7 @@ class SqlAlchemyMatchTest(TestCase):
         )
         self.assertSQL(
             "SELECT characters.name AS characters_name FROM characters "
-            + "WHERE match((characters.name 0.5), ?)",
+            + "WHERE match((characters.name 0.5), %(param_1)s)",
             query,
         )
 
@@ -92,7 +92,7 @@ class SqlAlchemyMatchTest(TestCase):
         self.assertSQL(
             "SELECT characters.name AS characters_name FROM characters "
             + "WHERE match("
-            + "(characters.info['race'] 0.9, characters.name 0.5), ?"
+            + "(characters.info['race'] 0.9, characters.name 0.5), %(param_1)s"
             + ")",
             query,
         )
@@ -109,7 +109,7 @@ class SqlAlchemyMatchTest(TestCase):
         self.assertSQL(
             "SELECT characters.name AS characters_name FROM characters "
             + "WHERE match("
-            + "(characters.info['race'] 0.9, characters.name 0.5), ?"
+            + "(characters.info['race'] 0.9, characters.name 0.5), %(param_1)s"
             + ") using phrase with (analyzer=english, fuzziness=3)",
             query,
         )
@@ -120,7 +120,7 @@ class SqlAlchemyMatchTest(TestCase):
         )
         self.assertSQL(
             "SELECT characters.name AS characters_name, _score "
-            + "FROM characters WHERE match(characters.name, ?)",
+            + "FROM characters WHERE match(characters.name, %(param_1)s)",
             query,
         )
 

--- a/tests/update_test.py
+++ b/tests/update_test.py
@@ -75,16 +75,19 @@ class SqlAlchemyUpdateTest(TestCase):
         char.age = 40
         self.session.commit()
 
-        expected_stmt = "UPDATE characters SET age = ?, ts = ? WHERE characters.name = ?"
+        expected_stmt = (
+            "UPDATE characters SET age = %(age)s, ts = %(ts)s "
+            "WHERE characters.name = %(characters_name)s"
+        )
         args, kwargs = fake_cursor.execute.call_args
         stmt = args[0]
         args = args[1]
         self.assertEqual(expected_stmt, stmt)
-        self.assertEqual(40, args[0])
-        dt = datetime.strptime(args[1], "%Y-%m-%dT%H:%M:%S.%f")
+        self.assertEqual(40, args["age"])
+        dt = datetime.strptime(args["ts"], "%Y-%m-%dT%H:%M:%S.%f")
         self.assertIsInstance(dt, datetime)
         self.assertGreater(dt, now)
-        self.assertEqual("Arthur", args[2])
+        self.assertEqual("Arthur", args["characters_name"])
 
     @patch("crate.client.connection.Cursor", FakeCursor)
     def test_bulk_update(self):
@@ -104,13 +107,13 @@ class SqlAlchemyUpdateTest(TestCase):
 
         self.session.commit()
 
-        expected_stmt = "UPDATE characters SET name = ?, obj = ?, ts = ?"
+        expected_stmt = "UPDATE characters SET name = %(name)s, obj = %(obj)s, ts = %(ts)s"
         args, kwargs = fake_cursor.execute.call_args
         stmt = args[0]
         args = args[1]
         self.assertEqual(expected_stmt, stmt)
-        self.assertEqual("Julia", args[0])
-        self.assertEqual({"favorite_book": "Romeo & Juliet"}, args[1])
-        dt = datetime.strptime(args[2], "%Y-%m-%dT%H:%M:%S.%f")
+        self.assertEqual("Julia", args["name"])
+        self.assertEqual({"favorite_book": "Romeo & Juliet"}, args["obj"])
+        dt = datetime.strptime(args["ts"], "%Y-%m-%dT%H:%M:%S.%f")
         self.assertIsInstance(dt, datetime)
         self.assertGreater(dt, before_update_time)

--- a/tests/vector_test.py
+++ b/tests/vector_test.py
@@ -78,7 +78,7 @@ class SqlAlchemyVectorTypeTest(TestCase):
         self.table.create(self.engine)
         fake_cursor.execute.assert_called_with(
             ("\nCREATE TABLE testdrive (\n\tname STRING, \n\tdata FLOAT_VECTOR(3)\n)\n\n"),
-            (),
+            sa.util.immutabledict({}),
         )
 
     def test_insert_invoke(self):
@@ -86,8 +86,8 @@ class SqlAlchemyVectorTypeTest(TestCase):
         with self.engine.connect() as conn:
             conn.execute(stmt)
         fake_cursor.execute.assert_called_with(
-            ("INSERT INTO testdrive (name, data) VALUES (?, ?)"),
-            ("foo", [42.42, 43.43, 44.44]),
+            ("INSERT INTO testdrive (name, data) VALUES (%(name)s, %(data)s)"),
+            {"name": "foo", "data": [42.42, 43.43, 44.44]},
         )
 
     def test_select_invoke(self):
@@ -96,7 +96,7 @@ class SqlAlchemyVectorTypeTest(TestCase):
             conn.execute(stmt)
         fake_cursor.execute.assert_called_with(
             ("SELECT testdrive.data \nFROM testdrive"),
-            (),
+            {},
         )
 
     def test_sql_select(self):
@@ -108,7 +108,7 @@ class SqlAlchemyVectorTypeTest(TestCase):
         )
         self.assertSQL(
             "SELECT testdrive.name AS testdrive_name "
-            "FROM testdrive WHERE KNN_MATCH(testdrive.data, ?, ?)",
+            "FROM testdrive WHERE KNN_MATCH(testdrive.data, %(param_1)s, %(param_2)s)",
             query,
         )
 


### PR DESCRIPTION
## About
A few adjustments were necessary to accommodate the test suite to upstream changes in [crate-python 2.2.0](https://github.com/crate/crate-python/releases/tag/2.2.0). The updates show that the improvement might have an impact to downstream users, so we might want to handle it with more care even in retrospective.

## References
- https://github.com/crate/crate-python/pull/795
- https://github.com/crate/crate-python/pull/796
- https://github.com/crate/crate-python/issues/806
