### PR TITLE
Release version 0.43.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2026/06/17 0.43.0
 - Types: Improved support for FLOAT type, converging to FLOAT vs. DOUBLE
 - Types: Added method `ObjectArray.as_generic` for better reverse type lookups
 - Types: Improved type mappings for better reverse type lookups / reflections


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Types: Improved support for FLOAT type, converging to FLOAT vs. DOUBLE
- Types: Added method `ObjectArray.as_generic` for better reverse type lookups
- Types: Improved type mappings for better reverse type lookups / reflections
  - Consequently used upper-case type definitions from `sqlalchemy.types`
  - Added `timestamp without time zone` types (scalar and array)
  - On SQLAlchemy 2, mapped `real` and `double{_precision}` types to the
    newly introduced `sqltypes.{DOUBLE,DOUBLE_PRECISION}` types
- Compiler: Made `CREATE INDEX` a no-op, only emitting `SELECT 1`, because CrateDB
  does not support that statement
- Compiler: Fixed `AttributeError: 'CrateCompilerSA20' object has no attribute
  'visit_on_conflict_do_update'` by forwarding calls to
  `PGCompiler.visit_on_conflict_do_update`
- Dialect: Added methods concerned with isolation levels as no-ops
- Types: Started emulating PostgreSQL's `JSON(B)` types using CrateDB's `OBJECT`
- Dialect: now uses `paramstyle = "pyformat"` supported in crate-python 2.2.1.
  Because of this the SQL statements logged or inspected will contain
  `%(name)s` placeholders instead of `?`.
- Removed support for Python versions < 3.10

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #258
