### PR TITLE
Compiler: Forwarding calls to `PGCompiler.visit_on_conflict_do_update`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- Compiler: Fixed `AttributeError: 'CrateCompilerSA20' object has no attribute
+  'visit_on_conflict_do_update'` by forwarding calls to
+  `PGCompiler.visit_on_conflict_do_update`
+
 ## 2026/06/17 0.43.0
 - Types: Improved support for FLOAT type, converging to FLOAT vs. DOUBLE
 - Types: Added method `ObjectArray.as_generic` for better reverse type lookups
@@ -10,9 +15,6 @@
     newly introduced `sqltypes.{DOUBLE,DOUBLE_PRECISION}` types
 - Compiler: Made `CREATE INDEX` a no-op, only emitting `SELECT 1`, because CrateDB
   does not support that statement
-- Compiler: Fixed `AttributeError: 'CrateCompilerSA20' object has no attribute
-  'visit_on_conflict_do_update'` by forwarding calls to
-  `PGCompiler.visit_on_conflict_do_update`
 - Dialect: Added methods concerned with isolation levels as no-ops
 - Types: Started emulating PostgreSQL's `JSON(B)` types using CrateDB's `OBJECT`
 - Dialect: now uses `paramstyle = "pyformat"` supported in crate-python 2.2.1.

--- a/src/sqlalchemy_cratedb/compiler.py
+++ b/src/sqlalchemy_cratedb/compiler.py
@@ -213,9 +213,6 @@ class CrateDDLCompiler(compiler.DDLCompiler):
 
 
 class CrateTypeCompiler(compiler.GenericTypeCompiler):
-    visit_on_conflict_do_update = PGCompiler.visit_on_conflict_do_update
-    _on_conflict_target = PGCompiler._on_conflict_target
-
     def visit_string(self, type_, **kw):
         return "STRING"
 
@@ -297,6 +294,9 @@ class CrateTypeCompiler(compiler.GenericTypeCompiler):
 
 
 class CrateCompiler(compiler.SQLCompiler):
+    visit_on_conflict_do_update = PGCompiler.visit_on_conflict_do_update
+    _on_conflict_target = PGCompiler._on_conflict_target
+
     def visit_getitem_binary(self, binary, operator, **kw):
         return "{0}['{1}']".format(self.process(binary.left, **kw), binary.right.value)
 


### PR DESCRIPTION
## About
Fixes `AttributeError: 'CrateCompilerSA20' object has no attribute 'visit_on_conflict_do_update'`.
GH-264 intended to do this already, but the patch added the dispatching to the wrong class.

## References
- GH-186
- https://github.com/crate/langchain-cratedb/blob/v0.2.0/langchain_cratedb/patches.py

/cc @bgunebakan, @kneth 