### PR TITLE
CI: Stop testing Python 3.7 through 3.9 on nightly runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         cratedb-version: ['nightly']
         sqla-version: ['latest']
         pip-allow-prerelease: ['false']


### PR DESCRIPTION
Resolve GH-274.