### PR TITLE
Fix `AttributeError: 'CrateCompilerSA20' object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- Compiler: Fixed `AttributeError: 'CrateCompilerSA20' object has no attribute
+  'visit_on_conflict_do_update'` by forwarding calls to
+  `PGCompiler.visit_on_conflict_do_update`
+
 ## 2026/06/17 0.43.0
 - Types: Improved support for FLOAT type, converging to FLOAT vs. DOUBLE
 - Types: Added method `ObjectArray.as_generic` for better reverse type lookups
@@ -10,9 +15,6 @@
     newly introduced `sqltypes.{DOUBLE,DOUBLE_PRECISION}` types
 - Compiler: Made `CREATE INDEX` a no-op, only emitting `SELECT 1`, because CrateDB
   does not support that statement
-- Compiler: Fixed `AttributeError: 'CrateCompilerSA20' object has no attribute
-  'visit_on_conflict_do_update'` by forwarding calls to
-  `PGCompiler.visit_on_conflict_do_update`
 - Dialect: Added methods concerned with isolation levels as no-ops
 - Types: Started emulating PostgreSQL's `JSON(B)` types using CrateDB's `OBJECT`
 - Dialect: now uses `paramstyle = "pyformat"` supported in crate-python 2.2.1.

--- a/src/sqlalchemy_cratedb/compiler.py
+++ b/src/sqlalchemy_cratedb/compiler.py
@@ -213,9 +213,6 @@ class CrateDDLCompiler(compiler.DDLCompiler):
 
 
 class CrateTypeCompiler(compiler.GenericTypeCompiler):
-    visit_on_conflict_do_update = PGCompiler.visit_on_conflict_do_update
-    _on_conflict_target = PGCompiler._on_conflict_target
-
     def visit_string(self, type_, **kw):
         return "STRING"
 
@@ -297,6 +294,9 @@ class CrateTypeCompiler(compiler.GenericTypeCompiler):
 
 
 class CrateCompiler(compiler.SQLCompiler):
+    visit_on_conflict_do_update = PGCompiler.visit_on_conflict_do_update
+    _on_conflict_target = PGCompiler._on_conflict_target
+
     def visit_getitem_binary(self, binary, operator, **kw):
         return "{0}['{1}']".format(self.process(binary.left, **kw), binary.right.value)
 

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 
 import sqlalchemy as sa
 from crate.client.cursor import Cursor
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import Update, text
 
 from sqlalchemy_cratedb.compiler import crate_before_execute
@@ -331,6 +332,24 @@ class SqlAlchemyCompilerTest(ParametrizedTestCase, ExtraAssertions):
             "it will be omitted when generating SQL statements.",
             str(w[-1].message),
         )
+
+    @skipIf(
+        SA_VERSION < SA_2_0,
+        "on_conflict_do_update is only exercised via CrateCompilerSA20",
+    )
+    def test_insert_on_conflict_do_update(self):
+        """
+        Verify that INSERT ... ON CONFLICT DO UPDATE compiles without
+        an error.
+        """
+        stmt = pg_insert(self.mytable).values(name="foo", data={"x": 1})
+        upsert = stmt.on_conflict_do_update(
+            index_elements=["name"],
+            set_={"data": {"x": 2}},
+        )
+        sql = str(upsert.compile(bind=self.crate_engine))
+        self.assertIn("ON CONFLICT (name)", sql)
+        self.assertIn("DO UPDATE SET data =", sql)
 
 
 FakeCursor = MagicMock(name="FakeCursor", spec=Cursor)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Moves `visit_on_conflict_do_update` and `_on_conflict_target` from `CrateTypeCompiler` to `CrateCompiler`. This is a bug fix for a misplaced method introduced in GH-264.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
 - [x] Added tests
